### PR TITLE
Add index page with centered flashcard and ChatGPT-inspired styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flashcards</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="flashcard">
+    <div class="image-placeholder">
+      <!-- Image goes here -->
+    </div>
+    <div class="word">Word</div>
+    <button class="audio-button">Play Audio</button>
+  </div>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,53 @@
+body {
+  background-color: #343541;
+  color: #ffffff;
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.flashcard {
+  background-color: #444654;
+  width: 320px;
+  height: 480px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.image-placeholder {
+  background-color: #565869;
+  width: 100%;
+  flex: 1;
+  border-radius: 4px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.word {
+  text-align: center;
+  margin-bottom: 16px;
+}
+
+.audio-button {
+  background-color: #10a37f;
+  color: #ffffff;
+  border: none;
+  border-radius: 4px;
+  padding: 10px 20px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.audio-button:hover {
+  background-color: #0e8c6a;
+}


### PR DESCRIPTION
## Summary
- Create index.html with a mobile-sized flashcard centered on the page including image space, word display, and audio button.
- Add styles.css mimicking ChatGPT's dark gray theme with white text and styled play button.

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6899b9cf709883308db41baaaca5fca4