### PR TITLE
Center review card and update flashcard styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -184,21 +184,23 @@ async function renderReview(query) {
   const wrap = document.createElement('div');
 wrap.innerHTML = `
   <h1 class="h1">Review <span class="muted">(${mode} • ${active.name})</span></h1>
-  <section class="card">
+  <section class="card card--center">
     <div class="flashcard" id="flashcard">
       <div class="flashcard-image" id="fcImg"></div>
-      <div class="flashcard-audio" id="fcAudioWrap"></div>
+
       <div class="flashcard-text">
         <div class="term" id="fcTerm"></div>
         <div class="translation muted" id="fcTrans" style="display:none"></div>
         <div class="example muted" id="fcEx"></div>
       </div>
+
       <div class="flashcard-actions">
         <button class="btn primary" id="revealBtn">${mode === 'quiz' ? 'Show Answer' : 'Show Translation'}</button>
         <button class="btn" id="audioBtn" style="display:none">Play Audio</button>
         <button class="btn" id="nextBtn">Next</button>
         <a class="btn" href="#/home">End Session</a>
       </div>
+
       <div class="flashcard-progress muted" id="fcProg"></div>
     </div>
   </section>
@@ -206,7 +208,6 @@ wrap.innerHTML = `
 
 let idx = 0;
 const img = wrap.querySelector('#fcImg');
-const audioWrap = wrap.querySelector('#fcAudioWrap');
 const term = wrap.querySelector('#fcTerm');
 const trans = wrap.querySelector('#fcTrans');
 const ex = wrap.querySelector('#fcEx');
@@ -218,10 +219,11 @@ const nextBtn = wrap.querySelector('#nextBtn');
 function renderCard() {
   const c = cards[idx];
   // image
-  img.innerHTML = c.image ? `<img src="${c.image}" alt="${c.front}">` : `<div class="no-image">No image</div>`;
+  img.innerHTML = c.image
+    ? `<img src="${c.image}" alt="${c.front}">`
+    : `<div class="no-image muted">No image</div>`;
   // audio
   audioBtn.style.display = c.audio ? '' : 'none';
-  audioWrap.innerHTML = ''; // (kept for future waveform/visualiser)
   // text
   term.textContent = (mode === 'quiz') ? c.back : c.front;
   trans.textContent = (mode === 'quiz') ? c.front : c.back;

--- a/styles/cards.css
+++ b/styles/cards.css
@@ -94,3 +94,86 @@
     height: 180px;
   }
 }
+
+/* Center the card inside the panel */
+.card.card--center {
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+/* Stacked flashcard layout with dark theme colors */
+.flashcard {
+  width: 100%;
+  max-width: 560px;
+  background: linear-gradient(180deg, var(--panel), var(--panel-2));
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* Image block – handles portrait & landscape */
+.flashcard-image {
+  width: 100%;
+  height: 320px;             /* desktop height */
+  background: #0c0e14;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+}
+.flashcard-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;        /* don’t crop; show full image */
+  background: #0c0e14;
+}
+
+/* Text */
+.flashcard-text {
+  text-align: center;
+  display: grid;
+  gap: 6px;
+}
+.flashcard-text .term {
+  font-size: 26px;
+  font-weight: 800;
+  color: var(--text);
+}
+.flashcard-text .translation { font-size: 18px; }
+.flashcard-text .example { font-size: 14px; }
+
+/* Actions – reuse .btn palette from base.css */
+.flashcard-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.flashcard-actions .btn {
+  min-width: 140px;
+  background: var(--panel);
+  border-color: var(--border);
+}
+.flashcard-actions .btn:hover {
+  border-color: var(--accent);
+}
+
+/* Progress text */
+.flashcard-progress {
+  text-align: center;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+/* Mobile tweaks */
+@media (max-width: 920px) {
+  .flashcard { max-width: 100%; padding: 14px; }
+  .flashcard-image { height: 220px; }
+  .flashcard-text .term { font-size: 22px; }
+}


### PR DESCRIPTION
## Summary
- Revamp review view markup for centered flashcard and consolidated actions
- Add dark-themed flashcard styles and responsive layout overrides
- Improve renderCard image fallback and keep CSV mapping intact

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899fd4f83c8833086da34bcab11a33c