### PR TITLE
Scale card images and unify button styling

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -55,6 +55,10 @@ body { background: var(--bg); color: var(--text); }
   border-radius: 12px;
   padding: 12px 16px;
   cursor: pointer;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 .btn:hover { border-color: var(--accent); }
 .btn.primary { border-color: var(--accent); }

--- a/styles/cards.css
+++ b/styles/cards.css
@@ -128,9 +128,11 @@
   place-items: center;
 }
 .flashcard-image img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;        /* don’t crop; show full image */
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;        /* scale down without cropping */
   background: #0c0e14;
 }
 
@@ -156,9 +158,13 @@
   justify-content: center;
 }
 .flashcard-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   min-width: 140px;
   background: var(--panel);
   border-color: var(--border);
+  text-decoration: none;
 }
 .flashcard-actions .btn:hover {
   border-color: var(--accent);


### PR DESCRIPTION
## Summary
- Scale flashcard images to stay within their container
- Center and style action buttons consistently, including End Session

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a005a347483308956685792085191