### PR TITLE
Fix flashcard audio and text styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -254,19 +254,6 @@ window.onkeydown = (e) => {
   if (e.key === 'ArrowRight' || e.key === 'Enter') { e.preventDefault(); nextBtn.click(); }
 };
 
-
-  // Reveal button action
-  wrap.querySelector('#revealBtn').addEventListener('click', () => {
-    alert(mode === 'quiz' ? `Answer: ${card.front}` : `Translation: ${card.back}`);
-  });
-
-  // Audio button action
-  if (card.audio) {
-    wrap.querySelector('#audioBtn').addEventListener('click', () => {
-      new Audio(card.audio).play();
-    });
-  }
-
   return wrap;
 }
 

--- a/styles/cards.css
+++ b/styles/cards.css
@@ -128,10 +128,8 @@
   place-items: center;
 }
 .flashcard-image img {
-  max-width: 100%;
-  max-height: 100%;
-  width: auto;
-  height: auto;
+  width: 100%;
+  height: 100%;
   object-fit: contain;        /* scale down without cropping */
   background: #0c0e14;
 }
@@ -143,9 +141,9 @@
   gap: 6px;
 }
 .flashcard-text .term {
-  font-size: 26px;
+  font-size: 32px;
   font-weight: 800;
-  color: var(--text);
+  color: #fff;
 }
 .flashcard-text .translation { font-size: 18px; }
 .flashcard-text .example { font-size: 14px; }


### PR DESCRIPTION
## Summary
- Ensure flashcard images scale to their containers without cropping
- Emphasize Welsh term beneath image with large white bold text
- Remove duplicate audio handler so playback only triggers for active card

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a028014e483308746ee35ce7e9a9f