### PR TITLE
Add previous navigation, auto audio, and image scaling

### DIFF
--- a/app.js
+++ b/app.js
@@ -195,9 +195,9 @@ wrap.innerHTML = `
       </div>
 
       <div class="flashcard-actions">
-        <button class="btn primary" id="revealBtn">${mode === 'quiz' ? 'Show Answer' : 'Show Translation'}</button>
-        <button class="btn" id="audioBtn" style="display:none">Play Audio</button>
-        <button class="btn" id="nextBtn">Next</button>
+        <button class="btn nav-btn" id="prevBtn">Previous</button>
+        <button class="btn nav-btn" id="audioBtn" style="display:none">Play Audio</button>
+        <button class="btn nav-btn" id="nextBtn">Next</button>
         <a class="btn" href="#/home">End Session</a>
       </div>
 
@@ -212,7 +212,7 @@ const term = wrap.querySelector('#fcTerm');
 const trans = wrap.querySelector('#fcTrans');
 const ex = wrap.querySelector('#fcEx');
 const prog = wrap.querySelector('#fcProg');
-const revealBtn = wrap.querySelector('#revealBtn');
+const prevBtn = wrap.querySelector('#prevBtn');
 const audioBtn = wrap.querySelector('#audioBtn');
 const nextBtn = wrap.querySelector('#nextBtn');
 
@@ -224,9 +224,11 @@ function renderCard() {
     : `<div class="no-image muted">No image</div>`;
   // audio
   audioBtn.style.display = c.audio ? '' : 'none';
+  if (c.audio) new Audio(c.audio).play();
   // text
   term.textContent = (mode === 'quiz') ? c.back : c.front;
   trans.textContent = (mode === 'quiz') ? c.front : c.back;
+  term.style.display = '';
   trans.style.display = 'none';
   ex.textContent = c.example || '';
   // progress
@@ -235,8 +237,13 @@ function renderCard() {
 
 renderCard();
 
-revealBtn.addEventListener('click', () => {
+term.addEventListener('click', () => {
+  term.style.display = 'none';
   trans.style.display = '';
+});
+trans.addEventListener('click', () => {
+  trans.style.display = 'none';
+  term.style.display = '';
 });
 audioBtn.addEventListener('click', () => {
   const c = cards[idx];
@@ -246,12 +253,16 @@ nextBtn.addEventListener('click', () => {
   idx = (idx + 1) % cards.length;
   renderCard();
 });
+prevBtn.addEventListener('click', () => {
+  idx = (idx - 1 + cards.length) % cards.length;
+  renderCard();
+});
 
 // keyboard shortcuts
 window.onkeydown = (e) => {
-  if (e.code === 'Space') { e.preventDefault(); revealBtn.click(); }
-  if (e.key?.toLowerCase() === 'a') { e.preventDefault(); audioBtn?.click(); }
   if (e.key === 'ArrowRight' || e.key === 'Enter') { e.preventDefault(); nextBtn.click(); }
+  if (e.key === 'ArrowLeft') { e.preventDefault(); prevBtn.click(); }
+  if (e.key?.toLowerCase() === 'a') { e.preventDefault(); audioBtn?.click(); }
 };
 
   return wrap;

--- a/styles/cards.css
+++ b/styles/cards.css
@@ -128,8 +128,11 @@
   place-items: center;
 }
 .flashcard-image img {
-  width: 100%;
-  height: 100%;
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
   object-fit: contain;        /* scale down without cropping */
   background: #0c0e14;
 }
@@ -166,6 +169,11 @@
 }
 .flashcard-actions .btn:hover {
   border-color: var(--accent);
+}
+
+.flashcard-actions .btn.nav-btn {
+  flex: 1 1 33.333%;
+  min-width: 0;
 }
 
 /* Progress text */


### PR DESCRIPTION
## Summary
- Replace translation reveal with Previous button and allow clicking card text to toggle languages
- Auto-play audio on card load and add keyboard/prev-next controls
- Fix desktop image scaling and equal-width action buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a05f1ec288330bfe9383a13e6bfd9