### PR TITLE
Display large white translation when card is clicked

### DIFF
--- a/app.js
+++ b/app.js
@@ -190,7 +190,7 @@ wrap.innerHTML = `
 
       <div class="flashcard-text">
         <div class="term" id="fcTerm"></div>
-        <div class="translation muted" id="fcTrans" style="display:none"></div>
+        <div class="translation" id="fcTrans" style="display:none"></div>
         <div class="example muted" id="fcEx"></div>
       </div>
 

--- a/styles/cards.css
+++ b/styles/cards.css
@@ -148,7 +148,11 @@
   font-weight: 800;
   color: #fff;
 }
-.flashcard-text .translation { font-size: 18px; }
+.flashcard-text .translation {
+  font-size: 32px;
+  font-weight: 800;
+  color: #fff;
+}
 .flashcard-text .example { font-size: 14px; }
 
 /* Actions – reuse .btn palette from base.css */


### PR DESCRIPTION
## Summary
- Show English translation in a large white font when revealed
- Remove muted styling so translated text is clear and prominent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a084ed2dc8330abf2edc881aa5baa