### PR TITLE
style: emphasize flashcard text

### DIFF
--- a/styles/cards.css
+++ b/styles/cards.css
@@ -58,15 +58,14 @@
   margin: 0.5rem 0 1rem;
 }
 
-.flashcard-text .term {
-  font-size: 1.5rem;
-  font-weight: bold;
+.flashcard-text .term,
+.flashcard-text .translation {
+  font-weight: 700;
+  color: var(--accent);
 }
 
-.flashcard-text .translation {
-  font-size: 1rem;
-  color: #666;
-}
+.flashcard-text .term { font-size: 1.5rem; }
+.flashcard-text .translation { font-size: 1rem; }
 
 .flashcard-actions {
   display: flex;
@@ -143,15 +142,11 @@
   display: grid;
   gap: 6px;
 }
-.flashcard-text .term {
-  font-size: 32px;
-  font-weight: 800;
-  color: #fff;
-}
+.flashcard-text .term,
 .flashcard-text .translation {
   font-size: 32px;
   font-weight: 800;
-  color: #fff;
+  color: var(--accent);
 }
 .flashcard-text .example { font-size: 14px; }
 


### PR DESCRIPTION
## Summary
- Use accent color and bold weight for flashcard terms and translations so text below images stands out

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/flashcards/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a15a7eb3c8330af2cdf7dc7401eb3