### PR TITLE
Arrange flashcard navigation buttons

### DIFF
--- a/app.js
+++ b/app.js
@@ -198,7 +198,7 @@ wrap.innerHTML = `
         <button class="btn nav-btn" id="prevBtn">Previous</button>
         <button class="btn nav-btn" id="audioBtn" style="display:none">Play Audio</button>
         <button class="btn nav-btn" id="nextBtn">Next</button>
-        <a class="btn" href="#/home">End Session</a>
+        <a class="btn end-btn" href="#/home">End Session</a>
       </div>
 
       <div class="flashcard-progress muted" id="fcProg"></div>

--- a/styles/cards.css
+++ b/styles/cards.css
@@ -171,7 +171,12 @@
 }
 
 .flashcard-actions .btn.nav-btn {
-  flex: 1 1 33.333%;
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.flashcard-actions .btn.end-btn {
+  flex: 1 0 100%;
   min-width: 0;
 }
 


### PR DESCRIPTION
## Summary
- Align flashcard navigation controls so previous, audio, and next buttons share the top row equally.
- Place the End Session button on its own row spanning full width.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a18c2b9fc8330a425317a9d351c2c