### PR TITLE
Remove duplicate flashcard text styles

### DIFF
--- a/styles/cards.css
+++ b/styles/cards.css
@@ -14,85 +14,6 @@
 
 @media (max-width: 920px) { .fc { grid-template-columns: 1fr; } }
 
-.flashcard {
-  background: var(--card-bg, #fff);
-  border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-  padding: 1rem;
-  max-width: 400px;
-  margin: auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.flashcard-image {
-  width: 100%;
-  height: 220px; /* Adjust for portrait/landscape mix */
-  overflow: hidden;
-  border-radius: 8px;
-}
-
-.flashcard-image img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover; /* Keeps aspect ratio but fills area */
-}
-
-.flashcard-audio {
-  margin: 1rem 0 0.5rem;
-}
-
-.audio-btn {
-  background: var(--accent-color, #007BFF);
-  color: #fff;
-  padding: 0.6rem 1rem;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  font-size: 1rem;
-}
-
-.flashcard-text {
-  text-align: center;
-  margin: 0.5rem 0 1rem;
-}
-
-.flashcard-text .term,
-.flashcard-text .translation {
-  font-weight: 700;
-  color: var(--accent);
-}
-
-.flashcard-text .term { font-size: 1.5rem; }
-.flashcard-text .translation { font-size: 1rem; }
-
-.flashcard-actions {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  justify-content: center;
-  width: 100%;
-}
-
-.flashcard-actions .btn {
-  flex: 1 1 auto;
-  padding: 0.6rem;
-  background: var(--button-bg, #f0f0f0);
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-}
-
-@media (max-width: 600px) {
-  .flashcard {
-    max-width: 100%;
-    padding: 0.8rem;
-  }
-  .flashcard-image {
-    height: 180px;
-  }
-}
 
 /* Center the card inside the panel */
 .card.card--center {
@@ -141,6 +62,7 @@
   text-align: center;
   display: grid;
   gap: 6px;
+  margin: 0.5rem 0 1rem;
 }
 .flashcard-text .term,
 .flashcard-text .translation {


### PR DESCRIPTION
## Summary
- Remove obsolete flashcard text CSS rules that overrode font-size changes
- Consolidate flashcard text styling and restore margin

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a1c27dae483309f7a6aac7b36f757