### PR TITLE
Ensure flashcard images remain square

### DIFF
--- a/styles/cards.css
+++ b/styles/cards.css
@@ -28,7 +28,7 @@
 
 .flashcard-image {
   width: 100%;
-  height: 220px; /* Adjust for portrait/landscape mix */
+  aspect-ratio: 1 / 1; /* Always square */
   overflow: hidden;
   border-radius: 8px;
 }
@@ -36,7 +36,7 @@
 .flashcard-image img {
   width: 100%;
   height: 100%;
-  object-fit: cover; /* Keeps aspect ratio but fills area */
+  object-fit: contain; /* Scale image inside the square */
 }
 
 .flashcard-audio {
@@ -90,7 +90,7 @@
     padding: 0.8rem;
   }
   .flashcard-image {
-    height: 180px;
+    aspect-ratio: 1 / 1;
   }
 }
 
@@ -118,7 +118,7 @@
 /* Image block – handles portrait & landscape */
 .flashcard-image {
   width: 100%;
-  height: 320px;             /* desktop height */
+  aspect-ratio: 1 / 1;             /* desktop height */
   background: transparent;
   border: 1px solid var(--border);
   border-radius: 12px;
@@ -190,6 +190,6 @@
 /* Mobile tweaks */
 @media (max-width: 920px) {
   .flashcard { max-width: 100%; padding: 14px; }
-  .flashcard-image { height: 220px; }
+  .flashcard-image { aspect-ratio: 1 / 1; }
   .flashcard-text .term { font-size: 22px; }
 }


### PR DESCRIPTION
## Summary
- Replace fixed heights with `aspect-ratio: 1 / 1` so flashcard images are always square
- Remove height overrides in responsive styles to maintain square aspect on all screens

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/flashcards/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a4f3177c083308c66960c47cc84ad