### PR TITLE
Hide mobile topbar title

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -91,6 +91,7 @@ button, .icon-btn, select { min-height: 40px; }
 /* Mobile layout */
 @media (max-width: 920px) {
   .topbar { display: grid; }
+  .topbar-title { display: none; }
   .layout { grid-template-columns: 1fr; }
   .side {
     position: fixed; inset: 56px 0 auto 0;


### PR DESCRIPTION
## Summary
- Hide the central title in the mobile top bar to declutter small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a55e97e1883309051ff5b3ad4da26