### PR TITLE
Fix translation toggle in review cards

### DIFF
--- a/app.js
+++ b/app.js
@@ -320,10 +320,11 @@ async function loadDeckData(deckId) {
     if (!res.ok) throw new Error(`Failed to load deck: ${deckId}`);
     const text = await res.text();
     const rows = parseCSV(text);
-    // Map CSV headers to existing card keys
+    // Map CSV headers to existing card keys. The CSV may use either
+    // `front/back` or the older `word/translation` column names.
     return rows.map(r => ({
-      front: r.word,
-      back: r.translation,
+      front: r.front || r.word,
+      back: r.back || r.translation,
       example: r.example,
       image: r.image,
       audio: r.audio,


### PR DESCRIPTION
## Summary
- Map CSV deck columns `front/back` (and legacy `word/translation`) to card fields so Welsh text toggles to English on click

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a5796da64833088f783561614178a