### PR TITLE
Increase flashcard text size and color via JS

### DIFF
--- a/app.js
+++ b/app.js
@@ -216,6 +216,12 @@ const prevBtn = wrap.querySelector('#prevBtn');
 const audioBtn = wrap.querySelector('#audioBtn');
 const nextBtn = wrap.querySelector('#nextBtn');
 
+// Increase card text size and make it white
+[term, trans].forEach(el => {
+  el.style.fontSize = '40px';
+  el.style.color = '#fff';
+});
+
 function renderCard() {
   const c = cards[idx];
   // image


### PR DESCRIPTION
## Summary
- enlarge card text beneath images and set it to white

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689a5c883b788330bb444968089a7942