### PR TITLE
Remove duplicate text from flashcards

### DIFF
--- a/app.js
+++ b/app.js
@@ -191,7 +191,6 @@ wrap.innerHTML = `
       <div class="flashcard-text">
         <div class="term" id="fcTerm"></div>
         <div class="translation hidden" id="fcTrans"></div>
-        <div class="example muted" id="fcEx"></div>
       </div>
 
       <div class="flashcard-actions">
@@ -210,17 +209,10 @@ let idx = 0;
 const img = wrap.querySelector('#fcImg');
 const term = wrap.querySelector('#fcTerm');
 const trans = wrap.querySelector('#fcTrans');
-const ex = wrap.querySelector('#fcEx');
 const prog = wrap.querySelector('#fcProg');
 const prevBtn = wrap.querySelector('#prevBtn');
 const audioBtn = wrap.querySelector('#audioBtn');
 const nextBtn = wrap.querySelector('#nextBtn');
-
-// Increase card text size and make it white
-[term, trans].forEach(el => {
-  el.style.fontSize = '40px';
-  el.style.color = '#fff';
-});
 
 function renderCard() {
   const c = cards[idx];
@@ -236,7 +228,6 @@ function renderCard() {
   trans.textContent = (mode === 'quiz') ? c.front : c.back;
   term.classList.remove('hidden');
   trans.classList.add('hidden');
-  ex.textContent = c.example || '';
   // progress
   prog.textContent = `Card ${idx + 1} of ${cards.length}`;
 }

--- a/styles/cards.css
+++ b/styles/cards.css
@@ -58,11 +58,10 @@
 }
 .flashcard-text .term,
 .flashcard-text .translation {
-  font-size: 32px;
+  font-size: 40px;
   font-weight: 800;
-  color: var(--accent);
+  color: #fff;
 }
-.flashcard-text .example { font-size: 14px; }
 
 /* Actions – reuse .btn palette from base.css */
 .flashcard-actions {


### PR DESCRIPTION
## Summary
- Drop redundant small example text beneath images on flashcards
- Style main flashcard text as large white lettering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a5ebaefe483308e75f3d1732e8c4f