### PR TITLE
Center flashcard layout and add iPhone scaling

### DIFF
--- a/styles/cards.css
+++ b/styles/cards.css
@@ -16,6 +16,10 @@
 
 
 /* Stacked flashcard layout with dark theme colors */
+.card--center {
+  display: flex;
+  justify-content: center;
+}
 .flashcard {
   width: 100%;
   max-width: 560px;
@@ -104,5 +108,11 @@
 @media (max-width: 920px) {
   .flashcard { max-width: 100%; padding: 14px; }
   .flashcard-image { aspect-ratio: 1 / 1; }
-  .flashcard-text .term { font-size: 22px; }
+  .flashcard-text .term,
+  .flashcard-text .translation { font-size: 22px; }
+}
+
+/* iPhone 13 Pro scale */
+@media (max-width: 430px) {
+  .flashcard { max-width: 390px; }
 }


### PR DESCRIPTION
## Summary
- Center flashcard within review section on desktop
- Scale flashcard text for small screens and add iPhone 13 Pro width limit

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689afbc19d008330b4c8997259120911