### PR TITLE
Autoplay flashcard audio and reset speed each card

### DIFF
--- a/js/study.js
+++ b/js/study.js
@@ -214,6 +214,10 @@ async function renderReview(query) {
 
   // initial render
   renderCard();
+  // autoplay new card at normal speed
+  slowNext = false;
+  const first = cards[idx];
+  if (first.audio) playAudio(first.audio);
 
   // interactions
   imgEl.addEventListener('click', () => {
@@ -235,12 +239,20 @@ async function renderReview(query) {
     idx = (idx + 1) % cards.length;
     showBack = false;
     renderCard();
+    // autoplay next card at normal speed
+    slowNext = false;
+    const c = cards[idx];
+    if (c.audio) playAudio(c.audio);
   });
   prevBtn.addEventListener('click', () => {
     stopAudio();
     idx = (idx - 1 + cards.length) % cards.length;
     showBack = false;
     renderCard();
+    // autoplay previous card at normal speed
+    slowNext = false;
+    const c = cards[idx];
+    if (c.audio) playAudio(c.audio);
   });
 
   // keyboard (desktop convenience)


### PR DESCRIPTION
## Summary
- Autoplay card audio when a flashcard is shown
- Reset playback speed to normal at the start of each new card

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b8bb961ec8330b1dfb9aab62d1262