### PR TITLE
Switch to new Welsh phrases CSV format

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,12 @@
    Single-button fast/slow audio
    =========================== */
 
-const DECKS = [{ id: 'welsh_basics', name: 'Welsh – Basics', count: 29 }];
+// Updated to use the new data file `welsh_phrases_A1.csv` which includes
+// additional metadata columns and uses `welsh`/`english` headers instead of
+// the previous `front`/`back` pair.
+const DECKS = [
+  { id: 'welsh_phrases_A1', name: 'Welsh – A1 Phrases', count: 116 }
+];
 
 const STORAGE = {
   theme: 'fc_theme',
@@ -238,7 +243,8 @@ function dailyNewCount(struggling, maxDaily = 5) {
 
 // Tiny CSV loader (local file)
 async function loadDeckRows(deckId) {
-  const res = await fetch('data/welsh_basics.csv');
+  // Load the new deck CSV which includes extra metadata and explicit Welsh/English headers
+  const res = await fetch(`data/${deckId}.csv`);
   if (!res.ok) throw new Error('Failed to load deck CSV');
   const text = await res.text();
   const lines = text.trim().split(/\r?\n/);
@@ -250,9 +256,12 @@ async function loadDeckRows(deckId) {
     return obj;
   });
   return rows.map(r => ({
+    card: r.card || '',
+    unit: r.unit || '',
+    section: r.section || '',
     id: r.id || '',
-    front: r.front || r.word || '',
-    back:  r.back  || r.translation || '',
+    front: r.welsh || r.front || r.word || '',
+    back:  r.english || r.back  || r.translation || '',
     tags:  r.tags || '',
   })).filter(r => r.id && r.front);
 }

--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -63,7 +63,7 @@
 
   // ---------- CSV loader ----------
   async function fetchDeckCSV() {
-    const res = await fetch('data/welsh_basics.csv');
+    const res = await fetch('data/welsh_phrases_A1.csv');
     if (!res.ok) throw new Error('Failed to load CSV');
     const text = await res.text();
     const lines = text.trim().split(/\r?\n/);
@@ -75,9 +75,12 @@
       return obj;
     });
     return rows.map(r => ({
+      card: r.card || '',
+      unit: r.unit || '',
+      section: r.section || '',
       id: r.id || '',
-      front: r.front || r.word || '',
-      back:  r.back  || r.translation || '',
+      front: r.welsh || r.front || r.word || '',
+      back:  r.english || r.back  || r.translation || '',
       image: r.image || '',
       audio: r.audio || '',
       phonetic: r.phonetic || '',

--- a/js/study.js
+++ b/js/study.js
@@ -280,12 +280,15 @@ function parseCSV(text) {
 
 async function loadDeckData(deckId) {
   try {
-    const res = await fetch('data/welsh_basics.csv');
+    // The CSV now follows the `welsh_phrases_A1.csv` format which includes
+    // extra metadata columns (`card`, `unit`, `section`) and uses `welsh`/
+    // `english` instead of `front`/`back`.
+    const res = await fetch(`data/${deckId}.csv`);
     if (!res.ok) throw new Error(`Failed to load deck: ${deckId}`);
     const text = await res.text();
     const rows = parseCSV(text);
     rows.forEach((r, i) => {
-      const expected = ['id','front','back','image','audio','example','tags','phonetic','word_breakdown','usage_note','pattern_examples','pattern_examples_en'];
+      const expected = ['card','unit','section','id','welsh','english','image','audio','example','tags','phonetic','word_breakdown','usage_note','pattern_examples','pattern_examples_en'];
       const missing = expected.filter(k => !(k in r));
       if (missing.length) {
         console.warn(`Row ${i+2} likely misparsed. Missing: ${missing.join(', ')}. Did a field with commas lack quotes?`, r);
@@ -293,9 +296,12 @@ async function loadDeckData(deckId) {
     });
 
     return rows.map(r => ({
+      card: r.card || '',
+      unit: r.unit || '',
+      section: r.section || '',
       id: r.id || '',
-      front: r.front || r.word || '',
-      back: r.back || r.translation || '',
+      front: r.welsh || r.front || r.word || '',
+      back: r.english || r.back || r.translation || '',
       example: r.example || '',
       image: r.image || '',
       audio: r.audio || '',

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -69,7 +69,7 @@
 
   // ---------- CSV ----------
   async function fetchDeckCSV() {
-    const res = await fetch('data/welsh_basics.csv');
+    const res = await fetch('data/welsh_phrases_A1.csv');
     if (!res.ok) throw new Error('Failed to load CSV');
     const text = await res.text();
     const lines = text.trim().split(/\r?\n/);
@@ -83,9 +83,12 @@
       return obj;
     });
     return rows.map(r => ({
+      card: r.card || '',
+      unit: r.unit || '',
+      section: r.section || '',
       id: r.id || '',
-      front: r.front || r.word || '',       // Welsh
-      back:  r.back  || r.translation || '',// English
+      front: r.welsh || r.front || r.word || '',       // Welsh
+      back:  r.english || r.back  || r.translation || '',// English
       audio: r.audio || ''                  // optional audio file
     })).filter(r => r.id && r.front && r.back);
   }


### PR DESCRIPTION
## Summary
- Use the new `welsh_phrases_A1.csv` deck with explicit `welsh`/`english` headers and additional metadata.
- Update all CSV loading utilities to map the new columns and support the extra metadata.
- Refresh dashboard and study/test/new phrase modes to read from the updated deck.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c6e494c34833083fb60bdf15ea785