### PR TITLE
Fix New Phrases Today launching new phrase flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,6 +108,9 @@ const routes = {
   stats: renderPlaceholder('Stats'),
   settings: renderPlaceholder('Settings'),
   test: renderTestShell,
+  // Provide a stub so the dashboard doesn't render over the
+  // dedicated New Phrase flow handled in `js/newPhrase.js`.
+  newPhrase: () => document.createElement('div'),
 };
 
 async function render() {


### PR DESCRIPTION
## Summary
- add `newPhrase` route stub so the dashboard doesn't overwrite the dedicated new phrase flow handled by `newPhrase.js`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689c83ebcdc48330ab53090aaf776a9d