### PR TITLE
Fix mobile sidebar toggle on mobile

### DIFF
--- a/app.js
+++ b/app.js
@@ -121,7 +121,7 @@ function parseHash() {
 
 /* ---------- Mobile menu ---------- */
 function initMobileMenu() {
-  const btn = document.querySelector('.menu-btn');
+  const btn = document.getElementById('menuToggle');
   const side = document.querySelector('.side');
   if (!btn || !side) return;
   btn.addEventListener('click', () => side.classList.toggle('open'));


### PR DESCRIPTION
## Summary
- Fix hamburger button selector so mobile sidebar opens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ca4262e088330a79396c813b58844