### PR TITLE
fix: restore deck loading for study and test modes

### DIFF
--- a/app.js
+++ b/app.js
@@ -199,11 +199,17 @@ function currentDay(deckId){
   return diff+1;
 }
 async function loadDeckRows(deckId){
-  const dk = deckKeyFromState();
+  const dk = deckId || deckKeyFromState();
   const res = await fetch(`data/${dk}.json`, { cache: 'no-cache' });
   if(!res.ok) throw new Error('Failed to load deck JSON');
   const data = await res.json();
   const rows = Object.values(data.by_status||{}).flat();
+  rows.sort((a,b)=>{
+    const u=String(a.unit).localeCompare(String(b.unit)); if(u) return u;
+    const s=String(a.section).localeCompare(String(b.section)); if(s) return s;
+    const c=(a.card||0)-(b.card||0); if(c) return c;
+    return String(a.id).localeCompare(String(b.id));
+  });
   return rows.map((r,i)=>({
     card: r.card||'',
     unit: r.unit||'',
@@ -211,8 +217,17 @@ async function loadDeckRows(deckId){
     id: r.id || String(i),
     front: r.welsh || r.front || r.word || '',
     back: r.english || r.back || r.translation || '',
-    tags: r.tags || ''
-  })).filter(r=>r.id && r.front);
+    tags: r.tags || '',
+    image: r.image || '',
+    audio: r.audio || '',
+    phonetic: r.pronunciation || r.phonetic || '',
+    example: r.example || '',
+    usage_note: r.usage_note || r.use || '',
+    word_breakdown: r.word_breakdown || r.grammar_notes || '',
+    pattern_examples: r.pattern_examples || '',
+    pattern_examples_en: r.pattern_examples_en || '',
+    slow_audio: r.slow_audio || ''
+  })).filter(r=>r.id && r.front && r.back);
 }
 function getDailyNewAllowance(deckId, unseenCount, allMastered){
   const key = todayKey();

--- a/js/study.js
+++ b/js/study.js
@@ -23,35 +23,8 @@ const attemptsKey = 'tm_attempts_v1';          // global attempts bucket (unchan
   }
 })();
 
-async function loadDeckSorted(){
-  const res = await fetch(`data/${dk}.json`, { cache: 'no-cache' });
-  const data = await res.json();
-  const rows = Array.isArray(data) ? data : (data.cards || data);
-  const mapRow = (r,i) => ({
-    id: r.id || r.card || `row_${i+1}`,
-    front: r.welsh || r.Welsh || r.front || r.cy || '',
-    back:  r.english || r.English || r.back || r.en || '',
-    unit:  r.unit || '', section: r.section || '',
-    card:  Number.isFinite(+r.card) ? +r.card : (i+1),
-    image: r.image || '',
-    audio: r.audio || '',
-    phonetic: r.pronunciation || r.phonetic || '',
-    example: r.example || '',
-    usage_note: r.usage_note || r.use || '',
-    word_breakdown: r.word_breakdown || r.grammar_notes || '',
-    pattern_examples: r.pattern_examples || '',
-    pattern_examples_en: r.pattern_examples_en || '',
-    slow_audio: r.slow_audio || '',
-    tags: r.tags || ''
-  });
-  const list = rows.map(mapRow).filter(x => x.id && x.front && x.back);
-  list.sort((a,b)=>{
-    const u = String(a.unit).localeCompare(String(b.unit)); if (u) return u;
-    const s = String(a.section).localeCompare(String(b.section)); if (s) return s;
-    const c = (a.card||0) - (b.card||0); if (c) return c;
-    return String(a.id).localeCompare(String(b.id));
-  });
-  return list;
+async function loadDeckSorted(deckId){
+  return await loadDeckRows(deckId || dk);
 }
 
 function loadProgressSeen(){
@@ -84,7 +57,7 @@ async function renderReview(query) {
 
   const dk = deckKeyFromState();
   const activeDeck = DECKS.find(d => d.id === dk);
-  const deck = await loadDeckSorted();
+  const deck = await loadDeckSorted(dk);
   const seen = loadProgressSeen();
   const attempts = loadAttempts();
   const cards = deck.filter(c => isActiveCard(c.id, seen, attempts));

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -23,25 +23,8 @@ const attemptsKey = 'tm_attempts_v1';          // global attempts bucket (unchan
   }
 })();
 
-async function loadDeckSorted(){
-  const res = await fetch(`data/${dk}.json`, { cache: 'no-cache' });
-  const data = await res.json();
-  const rows = Array.isArray(data) ? data : (data.cards || data);
-  const mapRow = (r,i) => ({
-    id: r.id || r.card || `row_${i+1}`,
-    front: r.welsh || r.Welsh || r.front || r.cy || '',
-    back:  r.english || r.English || r.back || r.en || '',
-    unit:  r.unit || '', section: r.section || '',
-    card:  Number.isFinite(+r.card) ? +r.card : (i+1),
-  });
-  const list = rows.map(mapRow).filter(x => x.id && x.front && x.back);
-  list.sort((a,b)=>{
-    const u = String(a.unit).localeCompare(String(b.unit)); if (u) return u;
-    const s = String(a.section).localeCompare(String(b.section)); if (s) return s;
-    const c = (a.card||0) - (b.card||0); if (c) return c;
-    return String(a.id).localeCompare(String(b.id));
-  });
-  return list;
+async function loadDeckSorted(deckId){
+  return await loadDeckRows(deckId || dk);
 }
 
 function loadProgressSeen(){
@@ -157,7 +140,7 @@ function logAttempt(cardId, pass){
 
   /* ---------- Data loading ---------- */
   async function buildActiveDeck() {
-    const deck = await loadDeckSorted();
+    const deck = await loadDeckSorted(dk);
     const seen = loadProgressSeen();
     const attempts = loadAttempts();
     const active = deck.filter(c => isActiveCard(c.id, seen, attempts));


### PR DESCRIPTION
## Summary
- extend deck loader to parse progress-based JSON and expose media fields
- reuse shared deck loader in study and test scripts

## Testing
- `node --check app.js`
- `node --check js/study.js`
- `node --check js/testMode.js`
- `node --check js/newPhrase.js`


------
https://chatgpt.com/codex/tasks/task_e_689cabb23f588330b4b92dbf9d26f826