### PR TITLE
Fix New Words view blank page

### DIFF
--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -385,6 +385,11 @@ const attemptsKey = 'tm_attempts_v1';          // global attempts bucket (unchan
   /* ---------- Boot ---------- */
   window.renderNewPhrase = renderNewPhrase;
 
+  // If the New Words route loaded before this script, re-render now that the view is ready.
+  if (location.hash.startsWith('#/newPhrase') && typeof render === 'function') {
+    render();
+  }
+
   // small style tweaks (reuse flashcard look)
   const style=document.createElement('style');
   style.textContent=`


### PR DESCRIPTION
## Summary
- Trigger rerender of New Words route after newPhrase.js loads so card displays

## Testing
- `node --check js/newPhrase.js`


------
https://chatgpt.com/codex/tasks/task_e_689ccd06424c83308e669438eaebd4b0