### PR TITLE
Ensure Test and New Phrase views initialize correctly

### DIFF
--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -386,8 +386,8 @@ const attemptsKey = 'tm_attempts_v1';          // global attempts bucket (unchan
   window.renderNewPhrase = renderNewPhrase;
 
   // If the New Words route loaded before this script, re-render now that the view is ready.
-  if (location.hash.startsWith('#/newPhrase') && typeof render === 'function') {
-    render();
+  if (location.hash.startsWith('#/newPhrase') && typeof window.renderNewPhrase === 'function') {
+    window.renderNewPhrase();
   }
 
   // small style tweaks (reuse flashcard look)

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -276,6 +276,11 @@
   window.addEventListener('DOMContentLoaded', mountIfTestRoute);
   window.addEventListener('hashchange', mountIfTestRoute);
 
+  // If the Test route was loaded before this script executed, mount immediately.
+  if (location.hash.startsWith('#/test')) {
+    mountIfTestRoute();
+  }
+
   /* ---------- Styles ---------- */
   const style = document.createElement('style');
   style.textContent = `


### PR DESCRIPTION
## Summary
- Render New Phrases view when route is loaded before script execution
- Mount Test Mode immediately if page loads on the test route

## Testing
- `node --check js/newPhrase.js`
- `node --check js/testMode.js`


------
https://chatgpt.com/codex/tasks/task_e_689ce53cbe508330b9c10d2ab3fc3b2d