### PR TITLE
Bind New Phrases navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 
       <nav class="nav" aria-label="Primary">
         <a href="#/home" data-route="home" class="active"><span>🏠</span> Home</a>
-        <a href="#/newPhrase" data-route="newPhrase"><span>🌱</span> New Words</a>
+        <a href="#/newPhrase" data-route="newPhrase" id="new-phrases"><span>🌱</span> New Phrases</a>
         <a href="#/review" data-route="review"><span>🔁</span> Review</a>
         <a href="#/test" data-route="test"><span>🧪</span> Test Mode</a>
         <a href="#/decks" data-route="decks"><span>📚</span> Decks</a>

--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -13,6 +13,43 @@ const progressKey = 'progress_' + dk;          // read/write here
 const dailyKey    = 'np_daily_' + dk;          // read in Test/Study; read/write in New Phrases
 const attemptsKey = 'tm_attempts_v1';          // global attempts bucket (unchanged)
 
+// --- Navigation binding --------------------------------------------------
+// Allow the "New Phrases" button to open the view while keeping existing
+// rendering logic intact. Works even if the menu is generated later.
+function openNewPhrasesView() {
+  // Hide all panels and reveal the new phrases panel if present
+  const panels = document.querySelectorAll('[data-panel]');
+  let target = null;
+  panels.forEach(p => {
+    const isTarget = p.getAttribute('data-panel') === 'new-phrases';
+    p.hidden = !isTarget;
+    if (isTarget) target = p;
+  });
+  if (!target) console.warn('New Phrases panel not found');
+
+  // Render the New Phrases content (router fallback if needed)
+  if (typeof window.renderNewPhrase === 'function') {
+    window.renderNewPhrase();
+  } else {
+    location.hash = '#/newPhrase';
+  }
+}
+window.openNewPhrasesView = openNewPhrasesView;
+
+document.addEventListener('DOMContentLoaded', () => {
+  const selector = '#new-phrases, [data-nav="new-phrases"], .js-new-phrases';
+  if (!document.querySelector(selector)) {
+    console.warn('New Phrases button not found');
+  }
+  document.addEventListener('click', e => {
+    const btn = e.target.closest(selector);
+    if (!btn) return;
+    e.preventDefault();
+    console.log('Opening New Phrases view');
+    openNewPhrasesView();
+  });
+});
+
 (function migrateProgressIfNeeded(){
   const legacy = 'progress_' + ((window.STATE && STATE.activeDeckId) || '');
   if (legacy !== progressKey) {


### PR DESCRIPTION
## Summary
- Wire up New Phrases navigation with delegated click handler and fallback routing
- Add global `openNewPhrasesView` to hide panels and render new phrases
- Mark sidebar link with `id="new-phrases"` so script can find it

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cf177ffcc83309fec64eeb11d14b4