### PR TITLE
Scope progress variables to avoid duplicates

### DIFF
--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -1,3 +1,4 @@
+(function(){
 function deckKeyFromState() {
   const map = {
     'Welsh – A1 Phrases': 'welsh_phrases_A1',
@@ -442,5 +443,7 @@ const attemptsKey = 'tm_attempts_v1';          // global attempts bucket (unchan
     .chip{ display:inline-block; border:1px solid var(--border); background:var(--panel); border-radius:999px; padding:4px 10px; font-size:12px; color:#fff; margin:2px; }
   `;
   document.head.appendChild(style);
+})();
+
 })();
 

--- a/js/study.js
+++ b/js/study.js
@@ -1,3 +1,4 @@
+(function(){
 function deckKeyFromState() {
   const map = {
     'Welsh – A1 Phrases': 'welsh_phrases_A1',
@@ -324,3 +325,5 @@ async function renderReview(query) {
 
   return wrap;
 }
+window.renderReview = renderReview;
+})();


### PR DESCRIPTION
## Summary
- Wrap `newPhrase.js` and `study.js` in IIFEs to keep `progressKey` and related variables scoped
- Export required functions to `window` to preserve existing API

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/newPhrase.js && node --check js/study.js`


------
https://chatgpt.com/codex/tasks/task_e_689d86a2ff2c8330a26fe4b15b3b47f3