### PR TITLE
harden client scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+js/firebase-config.js

--- a/index.html
+++ b/index.html
@@ -70,24 +70,27 @@
 
   <script>
     (function () {
-      window.addEventListener('error', function (e) {
-        var box = document.getElementById('errbox');
-        if (!box) {
-          box = document.createElement('div');
-          box.id = 'errbox';
-          box.style.position = 'fixed';
-          box.style.left = '0';
-          box.style.right = '0';
-          box.style.bottom = '0';
-          box.style.background = 'rgba(200,0,0,0.9)';
-          box.style.color = '#fff';
-          box.style.font = '12px/1.4 system-ui, sans-serif';
-          box.style.padding = '8px 12px';
-          box.style.zIndex = '99999';
-          document.body.appendChild(box);
-        }
-        box.textContent = '[JS Error] ' + e.message + ' @ ' + (e.filename || '') + ':' + (e.lineno || '');
-      });
+      var devHosts = ['localhost', '127.0.0.1'];
+      if (devHosts.includes(location.hostname)) {
+        window.addEventListener('error', function (e) {
+          var box = document.getElementById('errbox');
+          if (!box) {
+            box = document.createElement('div');
+            box.id = 'errbox';
+            box.style.position = 'fixed';
+            box.style.left = '0';
+            box.style.right = '0';
+            box.style.bottom = '0';
+            box.style.background = 'rgba(200,0,0,0.9)';
+            box.style.color = '#fff';
+            box.style.font = '12px/1.4 system-ui, sans-serif';
+            box.style.padding = '8px 12px';
+            box.style.zIndex = '99999';
+            document.body.appendChild(box);
+          }
+          box.textContent = '[JS Error] ' + e.message + ' @ ' + (e.filename || '') + ':' + (e.lineno || '');
+        });
+      }
     })();
   </script>
 
@@ -98,17 +101,7 @@
       getRedirectResult, signOut, onAuthStateChanged
     } from "https://www.gstatic.com/firebasejs/12.1.0/firebase-auth.js";
     import { getFirestore, doc, getDoc, setDoc } from "https://www.gstatic.com/firebasejs/12.1.0/firebase-firestore.js";
-
-    // --- Your config (from Firebase) ---
-    const firebaseConfig = {
-      apiKey: "AIzaSyAChauzqXrxR96_YMt0SJs2ygk9FQ6FpwU",
-      authDomain: "flashcards-app-2f89e.firebaseapp.com",
-      projectId: "flashcards-app-2f89e",
-      storageBucket: "flashcards-app-2f89e.firebasestorage.app",
-      messagingSenderId: "886681573920",
-      appId: "1:886681573920:web:65a3133bbbadfa645dfa45",
-      measurementId: "G-3JK7388FG1"
-    };
+    import { firebaseConfig } from "./js/firebase-config.js";
 
     // --- Init ---
     const app  = initializeApp(firebaseConfig);

--- a/js/firebase-config.sample.js
+++ b/js/firebase-config.sample.js
@@ -1,0 +1,9 @@
+export const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID",
+  measurementId: "YOUR_MEASUREMENT_ID"
+};

--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -128,8 +128,8 @@ function fireProgressEvent(payload){
   }
 
   async function syncProgressToGitHub(deckId, prog){
-    const token = localStorage.getItem('gh_token');
-    const repo  = localStorage.getItem('gh_repo'); // format: owner/repo
+    const token = sessionStorage.getItem('gh_token');
+    const repo  = sessionStorage.getItem('gh_repo'); // format: owner/repo
     if(!token || !repo) return;
     const path = `progress_${deckId}.json`;
     const content = btoa(unescape(encodeURIComponent(JSON.stringify(prog))));

--- a/js/study.js
+++ b/js/study.js
@@ -170,9 +170,18 @@ async function renderReview(query) {
     const isDetail = (STATE.viewMode === 'detail');
 
     // image
-    imgEl.innerHTML = c.image
-      ? `<img src="${c.image}" alt="${c.front}">`
-      : `<div class="no-image muted">No image</div>`;
+    imgEl.innerHTML = '';
+    if (c.image) {
+      const img = document.createElement('img');
+      img.src = c.image;
+      img.alt = c.front;
+      imgEl.appendChild(img);
+    } else {
+      const div = document.createElement('div');
+      div.className = 'no-image muted';
+      div.textContent = 'No image';
+      imgEl.appendChild(div);
+    }
 
     // phrase + phonetic
     if (isDetail) {


### PR DESCRIPTION
## Summary
- limit error overlay to local development
- load Firebase config from external file
- sanitize flashcard image rendering
- keep GitHub token in session storage instead of local storage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dec6671848330908ebe3829ff9a56