### PR TITLE
Enable enter key navigation in test mode

### DIFF
--- a/js/testMode.js
+++ b/js/testMode.js
@@ -202,11 +202,19 @@ function fireProgressEvent(payload){
         <div class="flashcard-actions"><button class="btn nav-btn" id="tm-next">Next</button></div>
         <div class="flashcard-progress muted">Card ${idx + 1} of ${deck.length}</div>
       </div>`;
-    container.querySelector('#tm-next').addEventListener('click', () => {
+    const nextBtn = container.querySelector('#tm-next');
+    function goNext(){
+      window.removeEventListener('keydown', onEnter);
       idx++;
       if (idx < deck.length) renderCard();
       else renderSummary();
-    });
+    }
+    function onEnter(e){
+      if(e.key === 'Enter'){ e.preventDefault(); goNext(); }
+    }
+    nextBtn.addEventListener('click', goNext);
+    window.addEventListener('keydown', onEnter);
+    focusField('#tm-next');
   }
 
   function renderSummary() {


### PR DESCRIPTION
## Summary
- Allow pressing Enter to advance to the next card in Test mode
- Focus the Next button after an answer is submitted for smoother keyboard navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dfe8b67848330a7c14a7d0916b986