### PR TITLE
fix: ensure dashboard filter buttons visible in dark mode

### DIFF
--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -46,9 +46,9 @@
   display:flex; justify-content:space-between; align-items:center; gap:12px; margin-bottom:8px;
 }
 .table-card .filters{ display:flex; gap:6px; align-items:center; flex-wrap:wrap; }
-.table-card .filters .pill{ border:1px solid var(--border); background:var(--panel); padding:6px 10px; border-radius:999px; font-size:12px; }
+.table-card .filters .pill{ border:1px solid var(--border); background:var(--panel); padding:6px 10px; border-radius:999px; font-size:12px; color:var(--text); }
 .table-card .filters .pill[aria-pressed="true"]{ outline:2px solid rgba(255,255,255,.15); }
-.table-card .filters .search{ padding:6px 10px; border:1px solid var(--border); background:var(--panel); border-radius:10px; color:#fff; }
+.table-card .filters .search{ padding:6px 10px; border:1px solid var(--border); background:var(--panel); border-radius:10px; color:var(--text); }
 
 .table-wrap{ overflow:auto; }
 table.data{ width:100%; border-collapse:separate; border-spacing:0 8px; }


### PR DESCRIPTION
## Summary
- ensure dashboard filter buttons inherit theme text color
- align search box text color with theme for dark/light modes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dff8c58d4833095ba2456f4d48c85