### PR TITLE
Show new and learning word statuses on dashboard

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -451,7 +451,8 @@ async function renderHome(){
   const enriched = activeRows.map(r=>{
     const arr = attempts[r.id] || [];
     const acc = lastNAccuracy(r.id,SCORE_WINDOW,attempts);
-    const status = categoryFromPct(acc);
+    let status = categoryFromPct(acc);
+    if (arr.length < 10) status = 'Learning';
     return {...r, acc, status, lastCount: arr.slice(-SCORE_WINDOW).length};
   });
 
@@ -471,10 +472,11 @@ async function renderHome(){
     if(seen[r.id] || (attempts[r.id] && attempts[r.id].length > 0)){
       const arr = attempts[r.id] || [];
       const acc = lastNAccuracy(r.id,SCORE_WINDOW,attempts);
-      const status = categoryFromPct(acc);
+      let status = categoryFromPct(acc);
+      if (arr.length < 10) status = 'Learning';
       todayList.push({...r, acc, status, lastCount: arr.slice(-SCORE_WINDOW).length});
     } else if(newRemaining > 0){
-      todayList.push({...r, acc:0, status:'Unseen', lastCount:0});
+      todayList.push({...r, acc:0, status:'New Word', lastCount:0});
       newRemaining--;
     }
   }

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -65,6 +65,8 @@ table.data tbody tr td:last-child{ border-radius:0 12px 12px 0; }
 .status.struggling{ background:#3b0e0e; }
 .status.needs-review{ background:#3b310e; }
 .status.mastered{ background:#0e283b; }
+.status.new-word{ background:#3b0e3b; }
+
 
 .acc{ display:flex; align-items:center; gap:8px; }
 .acc .bar{ width:120px; height:6px; background:#222831; border-radius:999px; overflow:hidden; }


### PR DESCRIPTION
## Summary
- Display unseen words as "New Word" with a purple badge on the dashboard
- Flag items with fewer than ten total attempts as "Learning"

## Testing
- `npm test` *(fails: could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689e05b24030833088cb9d812da10c7b