### PR TITLE
Implement 60-minute cooldown for confidence scoring

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -199,7 +199,9 @@ function loadAttemptsMap(){
   catch { return {}; }
 }
 function lastNAccuracy(cardId,n=SCORE_WINDOW,map=loadAttemptsMap()){
-  const arr = (map[cardId] || []).slice(-n);
+  const raw = map[cardId] || [];
+  const scored = raw.filter(a => a.score !== false);
+  const arr = scored.slice(-n);
   if (!arr.length) return 0;
   const p = arr.filter(a=>a.pass).length;
   return Math.round((p/arr.length)*100);
@@ -449,7 +451,7 @@ async function renderHome(){
   const unseenCount = unseenRows.length;
 
   const enriched = activeRows.map(r=>{
-    const arr = attempts[r.id] || [];
+    const arr = (attempts[r.id] || []).filter(a => a.score !== false);
     const acc = lastNAccuracy(r.id,SCORE_WINDOW,attempts);
     const status = categoryFromPct(acc);
     return {...r, acc, status, lastCount: arr.slice(-SCORE_WINDOW).length};
@@ -469,7 +471,7 @@ async function renderHome(){
   const todayList = [];
   for(const r of rows){
     if(seen[r.id] || (attempts[r.id] && attempts[r.id].length > 0)){
-      const arr = attempts[r.id] || [];
+      const arr = (attempts[r.id] || []).filter(a => a.score !== false);
       const acc = lastNAccuracy(r.id,SCORE_WINDOW,attempts);
       const status = categoryFromPct(acc);
       todayList.push({...r, acc, status, lastCount: arr.slice(-SCORE_WINDOW).length});

--- a/js/study.js
+++ b/js/study.js
@@ -42,10 +42,23 @@ function isActiveCard(id, seen, attempts){
   return !!(seen[id] || (attempts[id] && attempts[id].length));
 }
 
+const SCORE_COOLDOWN_MS = 60 * 60 * 1000; // 60 minutes
+
 function logAttempt(cardId, pass){
   const obj = loadAttempts();
   const arr = obj[cardId] || [];
-  arr.push({ ts: Date.now(), pass: !!pass });
+  const now = Date.now();
+  let score = true;
+  if (pass) {
+    for (let i = arr.length - 1; i >= 0; i--) {
+      const a = arr[i];
+      if (a.pass && a.score !== false) {
+        if (now - a.ts < SCORE_COOLDOWN_MS) score = false;
+        break;
+      }
+    }
+  }
+  arr.push({ ts: now, pass: !!pass, score });
   obj[cardId] = arr;
   localStorage.setItem(attemptsKey, JSON.stringify(obj));
 }

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -46,10 +46,23 @@ function fireProgressEvent(payload){
     return !!(seen[id] || (attempts[id] && attempts[id].length));
   }
 
+  const SCORE_COOLDOWN_MS = 60 * 60 * 1000; // 60 minutes
+
   function logAttempt(cardId, pass){
     const obj = loadAttempts();
     const arr = obj[cardId] || [];
-    arr.push({ ts: Date.now(), pass: !!pass });
+    const now = Date.now();
+    let score = true;
+    if (pass) {
+      for (let i = arr.length - 1; i >= 0; i--) {
+        const a = arr[i];
+        if (a.pass && a.score !== false) {
+          if (now - a.ts < SCORE_COOLDOWN_MS) score = false;
+          break;
+        }
+      }
+    }
+    arr.push({ ts: now, pass: !!pass, score });
     obj[cardId] = arr;
     localStorage.setItem(attemptsKey, JSON.stringify(obj));
     window.fcSaveCloud && window.fcSaveCloud();


### PR DESCRIPTION
## Summary
- Track whether correct attempts should count toward confidence using a 60-minute cooldown
- Update accuracy calculations and progress summaries to ignore unscored correct attempts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e1a9b8a248330bf982c3a92bb3d3b