### PR TITLE
Disable practice mode until test queue clears

### DIFF
--- a/js/testMode.js
+++ b/js/testMode.js
@@ -175,22 +175,15 @@ function fireProgressEvent(payload){
     return active;
   }
 
-  async function isDeckComplete() {
-    const rows = await loadDeckSorted(dk);
-    const attempts = loadAttempts();
-    return rows.every(r => {
-      const arr = attempts[r.id] || [];
-      return arr.some(a => a.pass && a.score !== false);
-    });
-  }
-
   async function checkPracticeUnlock() {
     const btn = document.getElementById('practiceToggle');
     const hint = document.getElementById('practiceHint');
     if (!btn) return;
-    const ok = await isDeckComplete();
-    btn.disabled = !ok;
-    if (hint) hint.style.display = ok ? 'none' : '';
+    const count = await (window.fcGetTestQueueCount ? window.fcGetTestQueueCount() : Promise.resolve(0));
+    const unlocked = count === 0;
+    btn.disabled = !unlocked;
+    btn.textContent = 'Practice (free retest)';
+    if (hint) hint.style.display = unlocked ? 'none' : '';
   }
 
   function updatePracticeUI() {


### PR DESCRIPTION
## Summary
- centralize test queue calculation and expose as `fcGetTestQueueCount`
- use shared count for dashboard and practice button
- disable "Practice (free retest)" until queue empty with helper text

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e355f30f0833082c2ede48750062b