### PR TITLE
Remove delay between new phrase audio replays

### DIFF
--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -148,12 +148,9 @@ function fireProgressEvent(payload){
     audioEl=new Audio(src); audioEl.playbackRate=rate;
     audioEl.play().catch(()=>{});
   }
-  function wait(ms){ return new Promise(res=>setTimeout(res,ms)); }
   async function playSequence(src){
     await playOne(src,1.0);
-    await wait(500);
     await playOne(src,0.6);
-    await wait(500);
     await playOne(src,1.0);
   }
   function playOne(src,rate){


### PR DESCRIPTION
## Summary
- eliminate half-second gap between auto replays when showing a new phrase card

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e377e06c48330a36f0d7bf0a1e6b0