### PR TITLE
Close mobile menu when clicking outside

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -153,6 +153,12 @@ function initMobileMenu() {
 
   btn.addEventListener('click', () => side.classList.toggle('open'));
 
+  document.addEventListener('click', (e) => {
+    if (!side.contains(e.target) && e.target !== btn && side.classList.contains('open')) {
+      side.classList.remove('open');
+    }
+  });
+
   document.querySelectorAll('.nav a').forEach(a =>
     a.addEventListener('click', (e) => {
       e.preventDefault();


### PR DESCRIPTION
## Summary
- Close the sidebar hamburger menu when a click occurs outside the menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e3935acf08330af31b2c7ddb81ed0