### PR TITLE
fix: prevent mobile auto-zoom on test inputs

### DIFF
--- a/js/testMode.js
+++ b/js/testMode.js
@@ -473,7 +473,7 @@ function fireProgressEvent(payload){
   const style = document.createElement('style');
   style.textContent = `
     .tm-label{font-size:12px;color:var(--muted);text-align:center;margin-top:6px;}
-    .tm-field{width:100%;margin-top:6px;padding:10px 12px;border:1px solid var(--border);border-radius:12px;background:var(--panel);color:#fff;}
+    .tm-field{width:100%;margin-top:6px;padding:10px 12px;border:1px solid var(--border);border-radius:12px;background:var(--panel);color:#fff;font-size:16px;}
     .tm-inputblock{margin-top:8px;}
     .tm-result{text-align:center;font-weight:800;margin-top:4px;}
     .tm-fail{color:#ff6b6b;}


### PR DESCRIPTION
## Summary
- prevent mobile browsers from auto-zooming in test mode by setting input font-size to 16px

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e3eeb28008330b1d3f7483025488f