### PR TITLE
Keep test stat title when practice mode active

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -516,12 +516,11 @@ async function renderHome(){
 
   const testBtn = wrap.querySelector('#btn-test');
   const testTitle = wrap.querySelector('#stat-test .title');
+  testTitle.textContent = 'Test Queue';
   if (testCount > 0) {
-    testTitle.textContent = 'Test Queue';
     testBtn.textContent = 'Start Test';
     testBtn.addEventListener('click', () => go('test'));
   } else {
-    testTitle.textContent = 'Practice';
     testBtn.textContent = 'Practice (free retest)';
     testBtn.addEventListener('click', () => go('test?practice=1'));
   }


### PR DESCRIPTION
## Summary
- Keep the dashboard's test stat card titled "Test Queue" even when no tests are available and practice mode is suggested

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e4bc994508330b64b0bdb061a7456