### PR TITLE
Use logo and reposition top bar controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,8 @@
   <!-- Desktop navbar -->
   <header class="navbar" role="banner">
     <div class="nav-left">
-      <div class="brand dragon">Draig</div>
+      <div class="brand dragon"><img src="media/image/welshlogo.png" alt="Draig logo"></div>
+      <select id="deckSelect" class="deck-select" aria-label="Switch deck"></select>
       <nav class="nav nav-horizontal" aria-label="Primary">
         <a href="#/home" data-route="home">Dashboard</a>
         <a href="#/newPhrase" data-route="newPhrase">Phrases</a>
@@ -24,15 +25,13 @@
         <a href="#/settings" data-route="settings">Settings</a>
       </nav>
     </div>
-    <div class="nav-right">
-      <select id="deckSelect" class="deck-select" aria-label="Switch deck"></select>
-    </div>
+    <div class="nav-right"></div>
   </header>
 
   <!-- Mobile topbar -->
   <header class="topbar">
     <button id="menuToggle" class="icon-btn" aria-label="Toggle menu">☰</button>
-    <div class="topbar-title">Draig</div>
+    <img src="media/image/welshlogo.png" alt="Draig logo" class="topbar-logo">
     <label class="toggle topbar-toggle" title="Light / Dark">
       <input type="checkbox" id="themeToggleTop" />
     </label>
@@ -145,18 +144,48 @@
     getRedirectResult(auth).then(async (res) => { if (res && res.user) await afterLogin(); }).catch(() => {});
 
     function ensureAuthUI() {
-      const host = document.querySelector(".side-footer") || document.body;
+      const host = document.querySelector(".nav-right") || document.querySelector(".side-footer") || document.body;
       let box = document.getElementById("authBox");
-      if (!box) { box = document.createElement("div"); box.id = "authBox"; box.style.display = "flex"; box.style.flexDirection = "column"; box.style.gap = "6px"; box.style.marginTop = "10px"; host.appendChild(box); }
-      if (!document.getElementById("authStatus")) { const s = document.createElement("div"); s.id = "authStatus"; s.className = "muted"; box.appendChild(s); }
-      if (!document.getElementById("authBtn")) { const b = document.createElement("button"); b.id = "authBtn"; b.className = "btn"; box.appendChild(b); }
+      if (!box) {
+        box = document.createElement("div");
+        box.id = "authBox";
+        box.style.display = "flex";
+        if (host.classList.contains("nav-right")) {
+          box.style.flexDirection = "row";
+          box.style.marginTop = "0";
+        } else {
+          box.style.flexDirection = "column";
+          box.style.marginTop = "10px";
+        }
+        box.style.gap = "6px";
+        host.appendChild(box);
+      }
+      if (!document.getElementById("authStatus") && !host.classList.contains("nav-right")) {
+        const s = document.createElement("div");
+        s.id = "authStatus";
+        s.className = "muted";
+        box.appendChild(s);
+      }
+      if (!document.getElementById("authBtn")) {
+        const b = document.createElement("button");
+        b.id = "authBtn";
+        b.className = "btn";
+        box.appendChild(b);
+      }
     }
     function renderAuthUI(user) {
       ensureAuthUI();
       const statusEl = document.getElementById("authStatus");
       const btn = document.getElementById("authBtn");
-      if (user) { statusEl.textContent = `Signed in as ${user.email}`; btn.textContent = "Sign out"; btn.onclick = signOutUser; }
-      else { statusEl.textContent = "Not signed in"; btn.textContent = "Sign in with Google"; btn.onclick = signInWithGoogle; }
+      if (user) {
+        if (statusEl) statusEl.textContent = `Signed in as ${user.email}`;
+        btn.textContent = "Sign out";
+        btn.onclick = signOutUser;
+      } else {
+        if (statusEl) statusEl.textContent = "Not signed in";
+        btn.textContent = "Sign in with Google";
+        btn.onclick = signInWithGoogle;
+      }
     }
     onAuthStateChanged(auth, (user) => renderAuthUI(user));
     document.addEventListener("DOMContentLoaded", () => renderAuthUI(auth.currentUser));

--- a/styles/base.css
+++ b/styles/base.css
@@ -81,7 +81,10 @@ body { background: var(--bg); color: var(--text); }
   background: var(--welsh-white);
   border-bottom: 4px solid var(--welsh-red);
 }
+.nav-left{ display:flex; align-items:center; gap:16px; }
+.nav-right{ display:flex; align-items:center; gap:16px; }
 .brand.dragon{ font-weight: 800; letter-spacing:.2px; color: var(--welsh-red); }
+.brand.dragon img{ height:40px; }
 .nav-horizontal{ display:flex; gap:14px; }
 .nav-horizontal a{
   display:inline-flex; align-items:center; gap:8px;
@@ -97,6 +100,7 @@ body { background: var(--bg); color: var(--text); }
 
 /* Mobile: show hamburger + drawer */
 .topbar { display: none; }
+.topbar-logo{ height:32px; justify-self:center; }
 .icon-btn {
   border: 1px solid var(--border);
   background: var(--panel);


### PR DESCRIPTION
## Summary
- Replace "Draig" text with Welsh logo image
- Move deck selector beside the logo and show Google auth button on the right
- Update scripts/styles to toggle sign-in and sign-out states in the header

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689f0cc47dfc8330ab351f2d483e024e