### PR TITLE
Shrink Welsh dragon icon and align language dropdown

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -81,10 +81,10 @@ body { background: var(--bg); color: var(--text); }
   background: var(--welsh-white);
   border-bottom: 4px solid var(--welsh-red);
 }
-.nav-left{ display:flex; align-items:center; gap:16px; }
+.nav-left{ display:flex; align-items:center; gap:8px; }
 .nav-right{ display:flex; align-items:center; gap:16px; }
 .brand.dragon{ font-weight: 800; letter-spacing:.2px; color: var(--welsh-red); }
-.brand.dragon img{ height:40px; }
+.brand.dragon img{ height:24px; }
 .nav-horizontal{ display:flex; gap:14px; }
 .nav-horizontal a{
   display:inline-flex; align-items:center; gap:8px;
@@ -100,7 +100,7 @@ body { background: var(--bg); color: var(--text); }
 
 /* Mobile: show hamburger + drawer */
 .topbar { display: none; }
-.topbar-logo{ height:32px; justify-self:center; }
+.topbar-logo{ height:24px; justify-self:center; }
 .icon-btn {
   border: 1px solid var(--border);
   background: var(--panel);


### PR DESCRIPTION
## Summary
- Reduce Welsh dragon logo size to a small symbol
- Decrease navbar gap so language dropdown sits immediately to the right of the dragon
- Match mobile topbar logo height to new smaller symbol

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f135e0f6c8330853625b9ace87dea