### PR TITLE
Fix desktop menu scroll

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -1,11 +1,13 @@
 /* Reset */
 * { box-sizing: border-box; }
-html, body { height: 100%; }
+html, body { height: auto; min-height: 100dvh; }
 body {
   margin: 0;
   font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Welsh palette */
@@ -69,7 +71,7 @@ body { background: var(--bg); color: var(--text); }
 .btn:hover { border-color: var(--accent); }
 
 /* Layout: sidebar hidden on desktop */
-.layout { display: grid; grid-template-columns: 1fr; min-height: 100dvh; }
+.layout { display: grid; grid-template-columns: 1fr; flex: 1; min-height: 0; }
 .main { padding: 24px; }
 .side { display: none; } /* default: hidden */
 


### PR DESCRIPTION
## Summary
- Prevent extra vertical scrolling by letting the layout fill remaining viewport height

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f16fb93b483308256ec97e32b9815