### PR TITLE
Add learned phrases list with progress tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       <select id="deckSelect" class="deck-select" aria-label="Switch deck"></select>
       <nav class="nav nav-horizontal" aria-label="Primary">
         <a href="#/home" data-route="home">Dashboard</a>
-        <a href="#/newPhrase" data-route="newPhrase">Phrases</a>
+        <a href="#/learned" data-route="learned">Learned Phrases</a>
         <a href="#/decks" data-route="decks">Custom Phrases</a>
         <a href="#/settings" data-route="settings">Settings</a>
       </nav>
@@ -42,7 +42,7 @@
     <aside class="side">
       <nav class="nav" aria-label="Primary">
         <a href="#/home" data-route="home" class="active">Dashboard</a>
-        <a href="#/newPhrase" data-route="newPhrase">Phrases</a>
+        <a href="#/learned" data-route="learned">Learned Phrases</a>
         <a href="#/decks" data-route="decks">Custom Phrases</a>
         <a href="#/settings" data-route="settings">Settings</a>
       </nav>

--- a/js/study.js
+++ b/js/study.js
@@ -87,6 +87,11 @@ async function renderReview(query) {
 
   // UI state
   let idx = 0;
+  const startId = query.get('card');
+  if (startId) {
+    const i = cards.findIndex(c => c.id === startId);
+    if (i >= 0) idx = i;
+  }
   let showBack = false;   // front(Welsh) → back(English) in flash mode
   let slowNext = false;   // audio alternator
   let audio = null;

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -410,11 +410,15 @@ function fireProgressEvent(payload){
     resetSession();
     container.innerHTML = `<div class="flashcard"><div class="flashcard-progress muted">Loading…</div></div>`;
     try {
+      const params = new URLSearchParams(location.hash.split('?')[1] || '');
+      const single = params.get('card');
       let active = await buildActiveDeck();
+      if (single) {
+        active = active.filter(c => c.id === single);
+      }
       if (!active.length) {
-        const params = new URLSearchParams(location.hash.split('?')[1] || '');
         const urlPractice = params.get('practice') === '1' || params.get('practice') === 'true';
-        if (urlPractice) {
+        if (!single && urlPractice) {
           active = await buildPracticeDeck();
           if (!active.length) {
             container.innerHTML = `<div class="flashcard"><div class="flashcard-progress muted">No cards available for practice.</div></div>`;

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -56,3 +56,9 @@
   box-shadow: inset 0 1px 0 rgba(0,0,0,.04);
 }
 .progress > i{ display:block; height:100%; width: var(--w, 0%); background: var(--welsh-red); }
+
+/* Learned phrases table */
+.phrase-table{ width:100%; border-collapse:collapse; margin-top:16px; font-size:14px; }
+.phrase-table th, .phrase-table td{ padding:8px 10px; border-bottom:1px solid var(--border); text-align:left; }
+.phrase-table th{ background: var(--panel-2); font-weight:700; }
+.phrase-table td.actions{ display:flex; gap:6px; }


### PR DESCRIPTION
## Summary
- Rename navigation link to "Learned Phrases" and add dedicated route
- List learned phrases with status, accuracy bar, attempt counts and study/test actions
- Support deep-linking to specific cards in review and test modes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f180d9cf883308e65341669a42eed