### PR TITLE
Style header green and border stats

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -80,8 +80,8 @@ body { background: var(--bg); color: var(--text); }
   position: sticky; top: 0; z-index: 40;
   display: flex; align-items: center; justify-content: space-between;
   gap: 16px; padding: 10px 16px;
-  background: var(--welsh-white);
-  border-bottom: 4px solid var(--welsh-red);
+  background: var(--welsh-green);
+  border-bottom: none;
 }
 .nav-left{ display:flex; align-items:center; gap:8px; }
 .nav-right{ display:flex; align-items:center; gap:16px; }
@@ -116,8 +116,8 @@ body { background: var(--bg); color: var(--text); }
     grid-template-columns: 40px 1fr 40px;
     align-items: center;
     position: sticky; top: 0; z-index: 30;
-    background: var(--panel);
-    border-bottom: 1px solid var(--border);
+    background: var(--welsh-green);
+    border-bottom: none;
     padding: 10px 12px;
   }
   .layout { grid-template-columns: 1fr; }
@@ -142,8 +142,8 @@ body, .main { background: #ffffff !important; }
 /* --- Lock to LIGHT mode & strengthen contrast --- */
 body { background: #ffffff !important; color: #0f1117 !important; }
 
-/* Make top nav definitely horizontal, dark text on white */
-.navbar { background:#fff; border-bottom:4px solid var(--welsh-red); }
+/* Make top nav definitely horizontal with green background */
+.navbar { background: var(--welsh-green); border-bottom: none; }
 .navbar .nav-horizontal { display:flex !important; flex-direction: row !important; gap:14px; }
 .navbar .nav-horizontal a { color:#0f1117; text-decoration:none; }
 .navbar .nav-horizontal a:hover,

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -35,7 +35,7 @@
 /* Right sidebar */
 .sidebar{ display:grid; gap:16px; }
 .panel-white{
-  background:#fff; border:1px solid var(--border); border-radius:16px;
+  background:#fff; border:1px solid var(--welsh-green); border-radius:16px;
   padding:16px; box-shadow: var(--shadow);
 }
 .panel-title{ font-weight:800; margin-bottom:8px; }


### PR DESCRIPTION
## Summary
- Give the header and mobile top bar a Welsh green background without the red underline
- Outline dashboard stats panels with the same Welsh green

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f1e9413c083308d587919e701e168