### PR TITLE
Add stats boxes to home dashboard

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -437,7 +437,7 @@ function go(route){
 
 
 /* ========= Mode selection dashboard ========= */
-function renderHome(){
+async function renderHome(){
   const wrap=document.createElement('div');
   wrap.innerHTML=`
     <div class="skills-grid">
@@ -472,8 +472,85 @@ function renderHome(){
         <div class="sub">Coming soon</div>
       </a>
     </div>
+
+    <div class="stats-grid">
+      <div class="panel-white stat-card" id="stat-phrases">
+        <div class="panel-title">Phrases</div>
+        <div class="ring" id="homePhraseRing"><span id="homePhraseRingTxt">0%</span></div>
+        <div class="list">
+          <div><span class="k">Today</span> · <span class="v" id="homePhraseToday">0/0</span></div>
+          <div><span class="k">Deck progress</span> · <span class="v" id="homePhraseProgLabel">0%</span></div>
+        </div>
+        <div class="progress" id="homePhraseProg"><i></i></div>
+      </div>
+      <div class="panel-white stat-card">
+        <div class="panel-title">Words</div>
+        <div class="ring"><span>0%</span></div>
+        <div class="list">
+          <div><span class="k">Today</span> · <span class="v">0/0</span></div>
+          <div><span class="k">Deck progress</span> · <span class="v">0%</span></div>
+        </div>
+        <div class="progress"><i></i></div>
+      </div>
+      <div class="panel-white stat-card">
+        <div class="panel-title">Songs</div>
+        <div class="ring"><span>0%</span></div>
+        <div class="list">
+          <div><span class="k">Today</span> · <span class="v">0/0</span></div>
+          <div><span class="k">Deck progress</span> · <span class="v">0%</span></div>
+        </div>
+        <div class="progress"><i></i></div>
+      </div>
+      <div class="panel-white stat-card">
+        <div class="panel-title">Stories</div>
+        <div class="ring"><span>0%</span></div>
+        <div class="list">
+          <div><span class="k">Today</span> · <span class="v">0/0</span></div>
+          <div><span class="k">Deck progress</span> · <span class="v">0%</span></div>
+        </div>
+        <div class="progress"><i></i></div>
+      </div>
+      <div class="panel-white stat-card">
+        <div class="panel-title">Conversations</div>
+        <div class="ring"><span>0%</span></div>
+        <div class="list">
+          <div><span class="k">Today</span> · <span class="v">0/0</span></div>
+          <div><span class="k">Deck progress</span> · <span class="v">0%</span></div>
+        </div>
+        <div class="progress"><i></i></div>
+      </div>
+      <div class="panel-white stat-card">
+        <div class="panel-title">Challenges</div>
+        <div class="ring"><span>0%</span></div>
+        <div class="list">
+          <div><span class="k">Today</span> · <span class="v">0/0</span></div>
+          <div><span class="k">Deck progress</span> · <span class="v">0%</span></div>
+        </div>
+        <div class="progress"><i></i></div>
+      </div>
+    </div>
   `;
   wrap.querySelectorAll('.skill').forEach(el=>el.addEventListener('click',e=>{e.preventDefault();go(el.dataset.target);}));
+
+  // phrase stats
+  const dk = deckKeyFromState();
+  const deckId = dk;
+  const prog  = JSON.parse(localStorage.getItem(progressKey) || '{"seen":{}}');
+  const rows  = await loadDeckRows(deckId);
+  const learned = Object.keys(prog.seen || {}).length;
+  const deckPct = rows.length ? Math.round((learned/rows.length)*100) : 0;
+
+  const daily = JSON.parse(localStorage.getItem(dailyKey) || '{}');
+  const allowed = daily.allowed || 0;
+  const used    = daily.used    || 0;
+  const pct     = allowed ? Math.round((used/allowed)*100) : 0;
+
+  wrap.querySelector('#homePhraseRing').style.setProperty('--pct', pct + '%');
+  wrap.querySelector('#homePhraseRingTxt').textContent = pct + '%';
+  wrap.querySelector('#homePhraseToday').textContent = `${used}/${allowed}`;
+  wrap.querySelector('#homePhraseProg').style.setProperty('--w', deckPct + '%');
+  wrap.querySelector('#homePhraseProgLabel').textContent = `${deckPct}%`;
+
   return wrap;
 }
 

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -9,6 +9,15 @@
   gap:28px; align-items:start;
 }
 
+.stats-grid{
+  display:grid; grid-template-columns: repeat(auto-fit, minmax(200px,1fr));
+  gap:28px; margin-top:40px; align-items:start;
+}
+
+.stat-card{ text-align:center; }
+
+.stat-card .progress{ margin-top:8px; }
+
 .skill{ text-align:center; text-decoration:none; color:inherit; user-select:none; }
 .skill .bubble{
   width: 160px; aspect-ratio: 1; border-radius: 50%;


### PR DESCRIPTION
## Summary
- Show a stats grid on the home dashboard with progress for Phrases and placeholders for other modules
- Compute and display daily and deck progress for phrases on the main page
- Add layout and styling for dashboard stat cards

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f2a63d3148330985af801f51b304f