### PR TITLE
Move home stats to sidebar

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -446,94 +446,51 @@ function go(route){
 async function renderHome(){
   const wrap=document.createElement('div');
   wrap.innerHTML=`
-    <div class="skills-grid">
-      <a class="skill" data-target="phrases" href="#/phrases">
-        <div class="bubble"><div class="emoji">💬</div></div>
-        <div class="label">Phrases</div>
-        <div class="sub">Start</div>
-      </a>
-      <a class="skill" data-target="words" href="#/words">
-        <div class="bubble"><div class="emoji">🔤</div></div>
-        <div class="label">Words</div>
-        <div class="sub">Coming soon</div>
-      </a>
-      <a class="skill" data-target="songs" href="#/songs">
-        <div class="bubble"><div class="emoji">🎵</div></div>
-        <div class="label">Songs</div>
-        <div class="sub">Coming soon</div>
-      </a>
-      <a class="skill" data-target="stories" href="#/stories">
-        <div class="bubble"><div class="emoji">📖</div></div>
-        <div class="label">Stories</div>
-        <div class="sub">Coming soon</div>
-      </a>
-      <a class="skill" data-target="conversations" href="#/conversations">
-        <div class="bubble"><div class="emoji">🗣️</div></div>
-        <div class="label">Conversations</div>
-        <div class="sub">Coming soon</div>
-      </a>
-      <a class="skill" data-target="challenges" href="#/challenges">
-        <div class="bubble"><div class="emoji">🏆</div></div>
-        <div class="label">Challenges</div>
-        <div class="sub">Coming soon</div>
-      </a>
-    </div>
-
-    <div class="stats-grid">
-      <div class="panel-white stat-card" id="stat-phrases">
-        <div class="panel-title">Phrases</div>
-        <div class="ring" id="homePhraseRing"><span id="homePhraseRingTxt">0%</span></div>
-        <div class="list">
-          <div><span class="k">Today</span> · <span class="v" id="homePhraseToday">0/0</span></div>
-          <div><span class="k">Deck progress</span> · <span class="v" id="homePhraseProgLabel">0%</span></div>
+    <div class="duo-layout">
+      <section>
+        <div class="skills-grid">
+          <a class="skill" data-target="phrases" href="#/phrases">
+            <div class="bubble"><div class="emoji">💬</div></div>
+            <div class="label">Phrases</div>
+            <div class="sub">Start</div>
+          </a>
+          <a class="skill" data-target="words" href="#/words">
+            <div class="bubble"><div class="emoji">🔤</div></div>
+            <div class="label">Words</div>
+            <div class="sub">Coming soon</div>
+          </a>
+          <a class="skill" data-target="songs" href="#/songs">
+            <div class="bubble"><div class="emoji">🎵</div></div>
+            <div class="label">Songs</div>
+            <div class="sub">Coming soon</div>
+          </a>
+          <a class="skill" data-target="stories" href="#/stories">
+            <div class="bubble"><div class="emoji">📖</div></div>
+            <div class="label">Stories</div>
+            <div class="sub">Coming soon</div>
+          </a>
+          <a class="skill" data-target="conversations" href="#/conversations">
+            <div class="bubble"><div class="emoji">🗣️</div></div>
+            <div class="label">Conversations</div>
+            <div class="sub">Coming soon</div>
+          </a>
+          <a class="skill" data-target="challenges" href="#/challenges">
+            <div class="bubble"><div class="emoji">🏆</div></div>
+            <div class="label">Challenges</div>
+            <div class="sub">Coming soon</div>
+          </a>
         </div>
-        <div class="progress" id="homePhraseProg"><i></i></div>
-      </div>
-      <div class="panel-white stat-card">
-        <div class="panel-title">Words</div>
-        <div class="ring"><span>0%</span></div>
-        <div class="list">
-          <div><span class="k">Today</span> · <span class="v">0/0</span></div>
-          <div><span class="k">Deck progress</span> · <span class="v">0%</span></div>
+      </section>
+      <aside class="sidebar">
+        <div class="panel-white stat-card" id="stat-phrases">
+          <div class="panel-title">Phrases</div>
+          <div class="ring" id="homePhraseRing"><span id="homePhraseRingTxt">0%</span></div>
+          <div class="list">
+            <div><span class="k">Today</span> · <span class="v" id="homePhraseToday">0/0</span></div>
+            <div><span class="k">Deck progress</span> · <span class="v" id="homePhraseProgLabel">0%</span></div>
+          </div>
         </div>
-        <div class="progress"><i></i></div>
-      </div>
-      <div class="panel-white stat-card">
-        <div class="panel-title">Songs</div>
-        <div class="ring"><span>0%</span></div>
-        <div class="list">
-          <div><span class="k">Today</span> · <span class="v">0/0</span></div>
-          <div><span class="k">Deck progress</span> · <span class="v">0%</span></div>
-        </div>
-        <div class="progress"><i></i></div>
-      </div>
-      <div class="panel-white stat-card">
-        <div class="panel-title">Stories</div>
-        <div class="ring"><span>0%</span></div>
-        <div class="list">
-          <div><span class="k">Today</span> · <span class="v">0/0</span></div>
-          <div><span class="k">Deck progress</span> · <span class="v">0%</span></div>
-        </div>
-        <div class="progress"><i></i></div>
-      </div>
-      <div class="panel-white stat-card">
-        <div class="panel-title">Conversations</div>
-        <div class="ring"><span>0%</span></div>
-        <div class="list">
-          <div><span class="k">Today</span> · <span class="v">0/0</span></div>
-          <div><span class="k">Deck progress</span> · <span class="v">0%</span></div>
-        </div>
-        <div class="progress"><i></i></div>
-      </div>
-      <div class="panel-white stat-card">
-        <div class="panel-title">Challenges</div>
-        <div class="ring"><span>0%</span></div>
-        <div class="list">
-          <div><span class="k">Today</span> · <span class="v">0/0</span></div>
-          <div><span class="k">Deck progress</span> · <span class="v">0%</span></div>
-        </div>
-        <div class="progress"><i></i></div>
-      </div>
+      </aside>
     </div>
   `;
   wrap.querySelectorAll('.skill').forEach(el=>el.addEventListener('click',e=>{e.preventDefault();go(el.dataset.target);}));
@@ -554,7 +511,6 @@ async function renderHome(){
   wrap.querySelector('#homePhraseRing').style.setProperty('--pct', pct + '%');
   wrap.querySelector('#homePhraseRingTxt').textContent = pct + '%';
   wrap.querySelector('#homePhraseToday').textContent = `${used}/${allowed}`;
-  wrap.querySelector('#homePhraseProg').style.setProperty('--w', deckPct + '%');
   wrap.querySelector('#homePhraseProgLabel').textContent = `${deckPct}%`;
 
   return wrap;

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -9,14 +9,7 @@
   gap:28px; align-items:start;
 }
 
-.stats-grid{
-  display:grid; grid-template-columns: repeat(auto-fit, minmax(200px,1fr));
-  gap:28px; margin-top:40px; align-items:start;
-}
-
 .stat-card{ text-align:center; }
-
-.stat-card .progress{ margin-top:8px; }
 
 .skill{ text-align:center; text-decoration:none; color:inherit; user-select:none; }
 .skill .bubble{


### PR DESCRIPTION
## Summary
- Rework home dashboard layout to use a two-column structure with a stats sidebar.
- Remove the unused progress bar chart from home stats card.
- Clean up dashboard styles by dropping stats-grid rules.

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f2e3b43d88330880cc6825a945cac