### PR TITLE
Center phrase dashboard and add play-all skill

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -447,8 +447,8 @@ async function renderHome(){
   const wrap=document.createElement('div');
   wrap.innerHTML=`
     <div class="duo-layout">
-      <section>
-        <div class="skills-grid">
+      <section class="skills-wrap">
+        <div class="skills-grid grid-3">
           <a class="skill" data-target="phrases" href="#/phrases">
             <div class="bubble"><div class="emoji">💬</div></div>
             <div class="label">Phrases</div>
@@ -561,7 +561,8 @@ async function renderPhraseDashboard(){
           Deck: <strong>${active.name}</strong> · Day <span id="day-count">1</span>
         </div>
 
-        <div class="skills-grid">
+        <div class="skills-wrap">
+        <div class="skills-grid grid-2">
           <a class="skill" id="sk-new">
             <div class="bubble">
               <div class="emoji">🌱</div>
@@ -588,10 +589,15 @@ async function renderPhraseDashboard(){
             <div class="label">Quiz</div>
             <div class="sub">Multiple choice / type</div>
           </a>
-        </div>
 
-        <div class="duo-cta">
-          <button class="btn primary" id="runAllBtn">Run All</button>
+          <a class="skill" id="sk-all">
+            <div class="bubble">
+              <div class="emoji">▶️</div>
+            </div>
+            <div class="label">Play All</div>
+            <div class="sub">Run modules</div>
+          </a>
+        </div>
         </div>
       </section>
 
@@ -636,7 +642,7 @@ async function renderPhraseDashboard(){
   wrap.querySelector('#sk-new').addEventListener('click', () => go('newPhrase'));
   wrap.querySelector('#sk-review').addEventListener('click', () => go('review'));
   wrap.querySelector('#sk-quiz').addEventListener('click', () => go('test'));
-  wrap.querySelector('#runAllBtn').addEventListener('click', () => window.runAllDaily && window.runAllDaily());
+  wrap.querySelector('#sk-all').addEventListener('click', () => window.runAllDaily && window.runAllDaily());
 
   return wrap;
 }

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -5,8 +5,23 @@
 @media (max-width: 920px){ .duo-layout{ grid-template-columns: 1fr; } }
 
 .skills-grid{
-  display:grid; grid-template-columns: repeat(auto-fit, minmax(160px,1fr));
+  display:grid;
+  justify-content:center;
+}
+.skills-grid.grid-3{
+  grid-template-columns: repeat(3,160px);
   gap:28px; align-items:start;
+}
+.skills-grid.grid-2{
+  grid-template-columns: repeat(2,160px);
+  gap:16px; align-items:start;
+}
+
+.skills-wrap{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  min-height: calc(100vh - 200px);
 }
 
 .stat-card{ text-align:center; }


### PR DESCRIPTION
## Summary
- Center home dashboard skills in a 2x3 grid
- Redesign phrase dashboard with 2x2 grid and circular Play All skill
- Add shared CSS helpers for centered skill grids

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f3159fd3c8330b4d85a2e13a78537