### PR TITLE
Stack dashboard icons vertically on mobile

### DIFF
--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -17,6 +17,13 @@
   gap:16px; align-items:start;
 }
 
+@media (max-width: 600px){
+  .skills-grid.grid-3,
+  .skills-grid.grid-2{
+    grid-template-columns: 160px;
+  }
+}
+
 .skills-wrap{
   display:flex;
   align-items:center;


### PR DESCRIPTION
## Summary
- Make dashboard skill grid one column on screens <=600px so icons stack vertically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f45ad466c833088030a04cfc714fb