### PR TITLE
Widen sidebar stats and add placeholders

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -490,6 +490,41 @@ async function renderHome(){
             <div><span class="k">Deck progress</span> · <span class="v" id="homePhraseProgLabel">0%</span></div>
           </div>
         </div>
+        <div class="panel-white stat-card">
+          <div class="panel-title">Words</div>
+          <div class="ring"><span>0%</span></div>
+          <div class="list">
+            <div><span class="k">Coming soon</span></div>
+          </div>
+        </div>
+        <div class="panel-white stat-card">
+          <div class="panel-title">Songs</div>
+          <div class="ring"><span>0%</span></div>
+          <div class="list">
+            <div><span class="k">Coming soon</span></div>
+          </div>
+        </div>
+        <div class="panel-white stat-card">
+          <div class="panel-title">Stories</div>
+          <div class="ring"><span>0%</span></div>
+          <div class="list">
+            <div><span class="k">Coming soon</span></div>
+          </div>
+        </div>
+        <div class="panel-white stat-card">
+          <div class="panel-title">Conversations</div>
+          <div class="ring"><span>0%</span></div>
+          <div class="list">
+            <div><span class="k">Coming soon</span></div>
+          </div>
+        </div>
+        <div class="panel-white stat-card">
+          <div class="panel-title">Challenges</div>
+          <div class="ring"><span>0%</span></div>
+          <div class="list">
+            <div><span class="k">Coming soon</span></div>
+          </div>
+        </div>
       </aside>
     </div>
   `;

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -1,6 +1,6 @@
 /* Duolingo-like dashboard */
 .duo-layout{
-  display:grid; grid-template-columns: 1fr 340px; gap:24px; align-items:start;
+  display:grid; grid-template-columns: 1fr 510px; gap:24px; align-items:start;
 }
 @media (max-width: 920px){ .duo-layout{ grid-template-columns: 1fr; } }
 


### PR DESCRIPTION
## Summary
- Increase dashboard sidebar column width by 50%
- Add placeholder stat cards for Words, Songs, Stories, Conversations and Challenges on the home dashboard

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f47dda23c8330a3c76dad3b88bdcb