### PR TITLE
Remove placeholder rings from non-phrase stat cards

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -492,35 +492,30 @@ async function renderHome(){
         </div>
         <div class="panel-white stat-card">
           <div class="panel-title">Words</div>
-          <div class="ring"><span>0%</span></div>
           <div class="list">
             <div><span class="k">Coming soon</span></div>
           </div>
         </div>
         <div class="panel-white stat-card">
           <div class="panel-title">Songs</div>
-          <div class="ring"><span>0%</span></div>
           <div class="list">
             <div><span class="k">Coming soon</span></div>
           </div>
         </div>
         <div class="panel-white stat-card">
           <div class="panel-title">Stories</div>
-          <div class="ring"><span>0%</span></div>
           <div class="list">
             <div><span class="k">Coming soon</span></div>
           </div>
         </div>
         <div class="panel-white stat-card">
           <div class="panel-title">Conversations</div>
-          <div class="ring"><span>0%</span></div>
           <div class="list">
             <div><span class="k">Coming soon</span></div>
           </div>
         </div>
         <div class="panel-white stat-card">
           <div class="panel-title">Challenges</div>
-          <div class="ring"><span>0%</span></div>
           <div class="list">
             <div><span class="k">Coming soon</span></div>
           </div>


### PR DESCRIPTION
## Summary
- Drop empty circular progress rings from dashboard stat cards for upcoming features
- Keep phrase ring to show phrase progress as before

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f49176a6883308b6f27d8fed77a57