### PR TITLE
Display current day in navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,9 @@
         <a href="#/settings" data-route="settings">Settings</a>
       </nav>
     </div>
-    <div class="nav-right"></div>
+      <div class="nav-right">
+        <div id="dayDisplay" class="day-display"></div>
+      </div>
   </header>
 
   <!-- Mobile topbar -->
@@ -65,6 +67,14 @@
 
   <!-- app/router last -->
   <script src="js/app.js" defer></script>
+
+  <!-- show current day -->
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const el = document.getElementById("dayDisplay");
+      if (el) el.textContent = new Date().getDate();
+    });
+  </script>
 
   <!-- tiny error banner (unchanged) -->
   <script>

--- a/styles/base.css
+++ b/styles/base.css
@@ -85,6 +85,17 @@ body { background: var(--bg); color: var(--text); }
 }
 .nav-left{ display:flex; align-items:center; gap:8px; }
 .nav-right{ display:flex; align-items:center; gap:16px; }
+.day-display{
+  color:#FFD447;
+  font-weight:bold;
+  border:4px solid #FFD447;
+  border-radius:50%;
+  width:40px;
+  height:40px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
 .brand.dragon{ font-weight: 800; letter-spacing:.2px; color: var(--welsh-red); }
 .brand.dragon img{ height:96px; }
 .nav-horizontal{ display:flex; gap:14px; }


### PR DESCRIPTION
## Summary
- Show current day number in the navbar next to the sign-in control
- Style day indicator with bold yellow text and circular border

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f4cf3ff1883309eca8d8e7da7b3c5