### PR TITLE
Reduce navigation bar height by half

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -79,18 +79,18 @@ body { background: var(--bg); color: var(--text); }
 .navbar{
   position: sticky; top: 0; z-index: 40;
   display: flex; align-items: center; justify-content: space-between;
-  gap: 16px; padding: 15px 16px;
+  gap: 16px; padding: 8px 16px;
   background: var(--welsh-green);
   border-bottom: none;
 }
 .nav-left{ display:flex; align-items:center; gap:8px; }
 .nav-right{ display:flex; align-items:center; gap:16px; }
 .brand.dragon{ font-weight: 800; letter-spacing:.2px; color: var(--welsh-red); }
-.brand.dragon img{ height:96px; }
+.brand.dragon img{ height:48px; }
 .nav-horizontal{ display:flex; gap:14px; }
 .nav-horizontal a{
   display:inline-flex; align-items:center; gap:8px;
-  padding:10px 14px; border-radius:12px; text-decoration:none; color:inherit;
+  padding:5px 14px; border-radius:12px; text-decoration:none; color:inherit;
   border:3px solid transparent;
 }
 .nav-horizontal a:hover,
@@ -98,17 +98,17 @@ body { background: var(--bg); color: var(--text); }
 .nav-horizontal a.active{ box-shadow:none; border-color: var(--welsh-white); }
 .deck-select{
   background: var(--panel); color: var(--text);
-  border: 1px solid var(--border); border-radius: 10px; padding: 8px 10px;
+  border: 1px solid var(--border); border-radius: 10px; padding: 4px 10px;
 }
 
 /* Mobile: show hamburger + drawer */
 .topbar { display: none; }
-.topbar-logo{ height:96px; justify-self:center; }
+.topbar-logo{ height:48px; justify-self:center; }
 .icon-btn {
   border: 1px solid var(--border);
   background: var(--panel);
   color: var(--text);
-  border-radius: 10px; padding: 8px; cursor: pointer;
+  border-radius: 10px; padding: 4px; cursor: pointer;
 }
 @media (max-width: 920px) {
   .navbar{ display:none; }
@@ -119,15 +119,15 @@ body { background: var(--bg); color: var(--text); }
     position: sticky; top: 0; z-index: 30;
     background: var(--welsh-green);
     border-bottom: none;
-    padding: 15px 12px;
+    padding: 8px 12px;
   }
   .layout { grid-template-columns: 1fr; }
   .side {
     display:block;
-    position: fixed; inset: 56px 0 auto 0;
+    position: fixed; inset: 64px 0 auto 0;
     transform: translateX(-100%); transition: transform .18s ease;
     width: 280px; max-width: 90vw;
-    height: calc(100dvh - 56px);
+    height: calc(100dvh - 64px);
     overflow: auto;
     box-shadow: var(--shadow);
     background: var(--panel);


### PR DESCRIPTION
## Summary
- Shrink desktop navigation bar with reduced padding and smaller logo.
- Match mobile topbar height by resizing logo, buttons, and drawer offset.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f4e26e4ec833091549fcbc16966cb