### PR TITLE
Refactor top nav with Welsh Sharp Pop styling

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -79,12 +79,12 @@ body { background: var(--bg); color: var(--text); }
 .navbar{
   position: sticky; top: 0; z-index: 40;
   display: flex; align-items: center; justify-content: space-between;
-  gap: 16px; padding: 8px 16px;
+  gap: 24px; padding: 8px 16px;
   background: var(--welsh-green);
   border-bottom: none;
 }
-.nav-left{ display:flex; align-items:center; gap:8px; }
-.nav-right{ display:flex; align-items:center; gap:16px; }
+.nav-left{ display:flex; align-items:center; gap:24px; }
+.nav-right{ display:flex; align-items:center; gap:24px; }
 .day-display{
   color:#FFD447;
   font-weight:bold;
@@ -98,30 +98,50 @@ body { background: var(--bg); color: var(--text); }
 }
 .brand.dragon{ font-weight: 800; letter-spacing:.2px; color: var(--welsh-red); }
 .brand.dragon img{ height:48px; }
-.nav-horizontal{ display:flex; gap:14px; }
+.nav-horizontal{ display:flex; gap:24px; }
 .nav-horizontal a{
-  display:inline-flex; align-items:center; gap:8px;
-  padding:5px 14px; border-radius:12px; text-decoration:none; color:inherit;
-  border:3px solid transparent;
+  display:inline-flex; align-items:center; justify-content:center; gap:8px;
+  height:40px; padding:0 16px;
+  border-radius:9999px; border:none;
+  text-decoration:none;
+  color:rgba(255,255,255,0.9);
+  font-weight:700;
+  transition: background .18s ease, color .18s ease, transform .18s ease;
 }
-.nav-horizontal a:hover,
-.nav-horizontal a.active{ background: rgba(209,17,28,0.12); }
-.nav-horizontal a.active{ box-shadow:none; border-color: var(--welsh-white); }
+.nav-horizontal a:hover{ background:rgba(255,255,255,.12); color:#fff; }
+.nav-horizontal a:focus-visible{ outline:2px solid #CFEEDA; outline-offset:2px; }
+.nav-horizontal a.active{
+  background:#fff; color:#1C8E4A;
+}
+.nav-horizontal a.active:hover,
+.nav-horizontal a.active:focus-visible{ transform:translateY(-1px); }
+#authBox{ display:flex; align-items:center; }
+#authBtn{
+  background:#C8102E; color:#fff;
+  border:none; border-radius:9999px;
+  height:40px; padding:0 16px;
+  font-weight:700;
+  box-shadow:0 2px 6px rgba(0,0,0,.12);
+  transition:background .18s ease, transform .18s ease;
+}
+#authBtn:hover{ background:#B30E28; }
+#authBtn:active{ transform:scale(.98); }
+#authBtn:focus-visible{ outline:2px solid #CFEEDA; outline-offset:2px; }
 .deck-select{
   background: var(--panel); color: var(--text);
-  border: 1px solid var(--border); border-radius: 10px; padding: 4px 10px;
+  border:none; border-radius:10px; padding:4px 10px;
 }
 
 /* Mobile: show hamburger + drawer */
 .topbar { display: none; }
 .topbar-logo{ height:48px; justify-self:center; }
 .icon-btn {
-  border: 1px solid var(--border);
+  border:none;
   background: var(--panel);
   color: var(--text);
-  border-radius: 10px; padding: 4px; cursor: pointer;
+  border-radius:10px; padding:4px; cursor:pointer;
 }
-@media (max-width: 920px) {
+@media (max-width: 768px) {
   .navbar{ display:none; }
   .topbar{
     display: grid;
@@ -154,12 +174,8 @@ body, .main { background: #ffffff !important; }
 /* --- Lock to LIGHT mode & strengthen contrast --- */
 body { background: #ffffff !important; color: #0f1117 !important; }
 
-/* Make top nav definitely horizontal with green background */
-.navbar { background: var(--welsh-green); border-bottom: none; }
-.navbar .nav-horizontal { display:flex !important; flex-direction: row !important; gap:14px; }
-.navbar .nav-horizontal a { color: var(--welsh-white); font-weight:700; text-decoration:none; }
-.navbar .nav-horizontal a:hover,
-.navbar .nav-horizontal a.active { background: rgba(209,17,28,.12); box-shadow: none; }
+/* Top nav tweaks */
+/* (all core navbar styling handled above) */
 
 /* Labels/subtitles darker */
 .h1 { color:#0f1117; }


### PR DESCRIPTION
## Summary
- Restyle desktop nav tabs into white pill active state, subtle hover lift, and accessible focus ring
- Add red pill Google auth button and spaced day-of-month indicator
- Tighten mobile breakpoint to 768px and remove borders for clean, modern look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f508e45488330948864b8114198bc