### PR TITLE
Fix low-contrast text on flashcard UI

### DIFF
--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -462,7 +462,7 @@ function fireProgressEvent(payload){
     .tm-label{ font-size:12px; color: var(--muted); text-align:center; }
     .tm-ansbox{ border:1px dashed var(--border); border-radius:10px; padding:8px 10px; margin-top:4px; background:rgba(255,255,255,0.02); }
     .tm-audio{ display:flex; justify-content:center; }
-    .chip{ display:inline-block; border:1px solid var(--border); background:var(--panel); border-radius:999px; padding:4px 10px; font-size:12px; color:#fff; margin:2px; }
+    .chip{ display:inline-block; border:1px solid var(--border); background:var(--panel); border-radius:999px; padding:4px 10px; font-size:12px; color:var(--text); margin:2px; }
   `;
   document.head.appendChild(style);
 })();

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -500,7 +500,7 @@ function fireProgressEvent(payload){
   const style = document.createElement('style');
   style.textContent = `
     .tm-label{font-size:12px;color:var(--muted);text-align:center;margin-top:6px;}
-    .tm-field{width:100%;margin-top:6px;padding:10px 12px;border:1px solid var(--border);border-radius:12px;background:var(--panel);color:#fff;font-size:16px;}
+    .tm-field{width:100%;margin-top:6px;padding:10px 12px;border:1px solid var(--border);border-radius:12px;background:var(--panel);color:var(--text);font-size:16px;}
     .tm-inputblock{margin-top:8px;}
     .tm-result{text-align:center;font-weight:800;margin-top:4px;}
     .tm-fail{color:#ff6b6b;}


### PR DESCRIPTION
## Summary
- Ensure test mode answer field uses theme text color instead of white
- Match chip pill text color to theme text for legible contrast

## Testing
- `node --check js/testMode.js`
- `node --check js/newPhrase.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f53c2000c8330885b31cfb5361283