### PR TITLE
Stop simultaneous audio playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
   </div>
 
   <!-- feature routes first -->
+  <script src="js/audioManager.js" defer></script>
   <script src="js/newPhrase.js" defer></script>
   <script src="js/study.js" defer></script>
   <script src="js/testMode.js" defer></script>

--- a/js/audioManager.js
+++ b/js/audioManager.js
@@ -1,0 +1,22 @@
+(function(){
+  let current=null;
+  function stop(){
+    if(current){
+      try{ current.pause(); }catch(e){}
+      current=null;
+    }
+  }
+  function create(src, rate=1.0){
+    if(!src) return null;
+    stop();
+    current=new Audio(src);
+    current.playbackRate=rate;
+    return current;
+  }
+  function play(src, rate=1.0){
+    const a=create(src, rate);
+    if(a) a.play().catch(()=>{});
+    return a;
+  }
+  window.fcAudio={ play, stop, create };
+})();

--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -142,11 +142,13 @@ function fireProgressEvent(payload){
 
   /* ---------- Audio ---------- */
   let audioEl=null;
-  function stopAudio(){ if(audioEl){ audioEl.pause(); audioEl=null; } }
+  function stopAudio(){
+    if(window.fcAudio) window.fcAudio.stop();
+    audioEl=null;
+  }
   function playAudio(src,rate=1){
-    if(!src) return; stopAudio();
-    audioEl=new Audio(src); audioEl.playbackRate=rate;
-    audioEl.play().catch(()=>{});
+    if(!src) return;
+    audioEl = window.fcAudio ? window.fcAudio.play(src,rate) : null;
   }
   async function playSequence(src){
     await playOne(src,1.0);
@@ -156,8 +158,8 @@ function fireProgressEvent(payload){
   function playOne(src,rate){
     return new Promise(res=>{
       if(!src) return res();
-      stopAudio();
-      audioEl=new Audio(src); audioEl.playbackRate=rate;
+      audioEl = window.fcAudio ? window.fcAudio.create(src,rate) : null;
+      if(!audioEl) return res();
       audioEl.addEventListener('ended',res,{once:true});
       audioEl.play().catch(()=>res());
     });

--- a/js/study.js
+++ b/js/study.js
@@ -94,7 +94,6 @@ async function renderReview(query) {
   }
   let showBack = false;   // front(Welsh) → back(English) in flash mode
   let slowNext = false;   // audio alternator
-  let audio = null;
 
   const wrap = document.createElement('div');
   wrap.innerHTML = `
@@ -161,15 +160,14 @@ async function renderReview(query) {
 
   // audio helpers
   function stopAudio() {
-    if (audio) { audio.pause(); audio = null; }
+    if (window.fcAudio) window.fcAudio.stop();
   }
   function playAudio(src) {
     if (!src) return;
     stopAudio();
-    audio = new Audio(src);
-    audio.playbackRate = slowNext ? 0.6 : 1.0; // alternate fast/slow
+    const rate = slowNext ? 0.6 : 1.0; // alternate fast/slow
+    if (window.fcAudio) window.fcAudio.play(src, rate);
     slowNext = !slowNext;
-    audio.play();
   }
 
   // parsing helpers


### PR DESCRIPTION
## Summary
- Add global audio manager to ensure only one audio file plays at a time
- Update study and new phrase views to use the shared audio manager
- Load audio manager script in index

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689f5d8068e083309e71d07ff992ef07