### PR TITLE
Add mobile day counter and auth button

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,9 +34,7 @@
   <header class="topbar">
     <button id="menuToggle" class="icon-btn" aria-label="Toggle menu">☰</button>
     <img src="media/image/welshlogo.png" alt="Draig logo" class="topbar-logo">
-    <label class="toggle topbar-toggle" title="Light / Dark">
-      <input type="checkbox" id="themeToggleTop" />
-    </label>
+    <div class="day-display"></div>
   </header>
 
   <div class="layout">
@@ -72,8 +70,9 @@
   <!-- show current day -->
   <script>
     document.addEventListener("DOMContentLoaded", () => {
-      const el = document.getElementById("dayDisplay");
-      if (el) el.textContent = new Date().getDate();
+      document.querySelectorAll(".day-display").forEach(el => {
+        el.textContent = new Date().getDate();
+      });
     });
   </script>
 
@@ -155,48 +154,44 @@
     getRedirectResult(auth).then(async (res) => { if (res && res.user) await afterLogin(); }).catch(() => {});
 
     function ensureAuthUI() {
-      const host = document.querySelector(".nav-right") || document.querySelector(".side-footer") || document.body;
-      let box = document.getElementById("authBox");
-      if (!box) {
-        box = document.createElement("div");
-        box.id = "authBox";
-        box.style.display = "flex";
-        if (host.classList.contains("nav-right")) {
-          box.style.flexDirection = "row";
-          box.style.marginTop = "0";
-        } else {
-          box.style.flexDirection = "column";
-          box.style.marginTop = "10px";
+      const hosts = [document.querySelector(".nav-right"), document.querySelector(".side-footer")].filter(Boolean);
+      hosts.forEach(host => {
+        let box = host.querySelector(".auth-box");
+        if (!box) {
+          box = document.createElement("div");
+          box.className = "auth-box";
+          box.style.display = "flex";
+          box.style.gap = "6px";
+          if (host.classList.contains("nav-right")) {
+            box.style.flexDirection = "row";
+            box.style.marginTop = "0";
+          } else {
+            box.style.flexDirection = "column";
+            box.style.marginTop = "10px";
+          }
+          host.appendChild(box);
         }
-        box.style.gap = "6px";
-        host.appendChild(box);
-      }
-      if (!document.getElementById("authStatus") && !host.classList.contains("nav-right")) {
-        const s = document.createElement("div");
-        s.id = "authStatus";
-        s.className = "muted";
-        box.appendChild(s);
-      }
-      if (!document.getElementById("authBtn")) {
-        const b = document.createElement("button");
-        b.id = "authBtn";
-        b.className = "btn";
-        box.appendChild(b);
-      }
+        if (!host.classList.contains("nav-right") && !box.querySelector(".auth-status")) {
+          const s = document.createElement("div");
+          s.className = "auth-status muted";
+          box.appendChild(s);
+        }
+        if (!box.querySelector(".auth-btn")) {
+          const b = document.createElement("button");
+          b.className = "auth-btn btn";
+          box.appendChild(b);
+        }
+      });
     }
     function renderAuthUI(user) {
       ensureAuthUI();
-      const statusEl = document.getElementById("authStatus");
-      const btn = document.getElementById("authBtn");
-      if (user) {
-        if (statusEl) statusEl.textContent = `Signed in as ${user.email}`;
-        btn.textContent = "Sign out";
-        btn.onclick = signOutUser;
-      } else {
-        if (statusEl) statusEl.textContent = "Not signed in";
-        btn.textContent = "Sign in with Google";
-        btn.onclick = signInWithGoogle;
-      }
+      document.querySelectorAll(".auth-status").forEach(el => {
+        el.textContent = user ? `Signed in as ${user.email}` : "Not signed in";
+      });
+      document.querySelectorAll(".auth-btn").forEach(btn => {
+        btn.textContent = user ? "Sign out" : "Sign in with Google";
+        btn.onclick = user ? signOutUser : signInWithGoogle;
+      });
     }
     onAuthStateChanged(auth, (user) => renderAuthUI(user));
     document.addEventListener("DOMContentLoaded", () => renderAuthUI(auth.currentUser));

--- a/styles/base.css
+++ b/styles/base.css
@@ -115,8 +115,8 @@ body { background: var(--bg); color: var(--text); }
 }
 .nav-horizontal a.active:hover,
 .nav-horizontal a.active:focus-visible{ transform:translateY(-1px); }
-#authBox{ display:flex; align-items:center; }
-#authBtn{
+.auth-box{ display:flex; align-items:center; }
+.auth-btn{
   background:#C8102E; color:#fff;
   border:none; border-radius:9999px;
   height:40px; padding:0 16px;
@@ -124,9 +124,9 @@ body { background: var(--bg); color: var(--text); }
   box-shadow:0 2px 6px rgba(0,0,0,.12);
   transition:background .18s ease, transform .18s ease;
 }
-#authBtn:hover{ background:#B30E28; }
-#authBtn:active{ transform:scale(.98); }
-#authBtn:focus-visible{ outline:2px solid #CFEEDA; outline-offset:2px; }
+.auth-btn:hover{ background:#B30E28; }
+.auth-btn:active{ transform:scale(.98); }
+.auth-btn:focus-visible{ outline:2px solid #CFEEDA; outline-offset:2px; }
 .deck-select{
   background: var(--panel); color: var(--text);
   border:none; border-radius:10px; padding:4px 10px;


### PR DESCRIPTION
## Summary
- Show current day in the mobile navbar
- Display Google sign-in/out in the mobile menu
- Style auth elements with reusable classes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f5f7e93048330b66d6fa3e75d61ad