### PR TITLE
Add Siarad brand bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Draig</title>
 
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&display=swap" rel="stylesheet">
+
   <!-- CSS -->
   <link rel="stylesheet" href="styles/base.css">
   <link rel="stylesheet" href="styles/menu.css">
@@ -36,6 +40,18 @@
     <img src="media/image/welshlogo.png" alt="Draig logo" class="topbar-logo">
     <div class="day-display"></div>
   </header>
+
+  <!-- Brand bar -->
+  <div class="brand-bar">
+    <a href="#/home" aria-label="Siarad Home" class="brand-link">
+      <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <circle cx="18" cy="18" r="18" fill="#C8102E" />
+        <rect x="6" y="9" width="24" height="18" rx="4" fill="#ffffff" />
+        <path d="M26 23 L30 27 L26 27 Z" fill="#ffffff" />
+      </svg>
+      <span class="brand-name">Siarad</span>
+    </a>
+  </div>
 
   <div class="layout">
     <!-- Sidebar (mobile drawer only) -->

--- a/styles/base.css
+++ b/styles/base.css
@@ -132,6 +132,31 @@ body { background: var(--bg); color: var(--text); }
   border:none; border-radius:10px; padding:4px 10px;
 }
 
+/* Brand bar */
+.brand-bar{
+  background:#ffffff;
+  border-bottom:1px solid #E9F5ED;
+  height:56px;
+  display:flex;
+  align-items:center;
+  padding:0 24px;
+}
+.brand-link{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  color:#C8102E;
+  font-family:'Poppins','Nunito',sans-serif;
+  font-weight:700;
+  font-size:24px;
+  letter-spacing:-0.5%;
+  text-decoration:none;
+}
+.brand-link svg{ width:36px; height:36px; }
+@media (max-width:420px){
+  .brand-name{ display:none; }
+}
+
 /* Mobile: show hamburger + drawer */
 .topbar { display: none; }
 .topbar-logo{ height:48px; justify-self:center; }


### PR DESCRIPTION
## Summary
- Add responsive brand bar with SVG Siarad logo linking to dashboard
- Load Poppins font for bold rounded "Siarad" wordmark
- Style bar with white background, red accent, and compact icon-only view under 420px

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f653149008330b6db872c07565723