### PR TITLE
Fix logo visibility and show mobile auth

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -153,9 +153,6 @@ body { background: var(--bg); color: var(--text); }
   text-decoration:none;
 }
 .brand-link svg{ width:36px; height:36px; }
-@media (max-width:420px){
-  .brand-name{ display:none; }
-}
 
 /* Mobile: show hamburger + drawer */
 .topbar { display: none; }

--- a/styles/menu.css
+++ b/styles/menu.css
@@ -14,5 +14,10 @@
 .side .nav a:hover { background: var(--panel-2); border-color: var(--border); }
 .side .nav a.active { background: var(--panel); border-color: var(--border); }
 
-/* Hide theme bits for now (uniform light) */
-.side-footer { display: none !important; }
+/* Footer inside the mobile menu for theme toggle and auth controls */
+.side-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 20px;
+}


### PR DESCRIPTION
## Summary
- Ensure Siarad text logo displays on all screen sizes
- Reveal mobile drawer footer so Google auth controls appear

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f6c3f61b88330aa11d6a1a29a6389