### PR TITLE
Center mobile logo and remove underline

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -156,7 +156,12 @@ body { background: var(--bg); color: var(--text); }
 
 /* Mobile: show hamburger + drawer */
 .topbar { display: none; }
-.topbar-logo{ height:48px; justify-self:center; }
+.topbar-logo{
+  height:48px;
+  justify-self:center;
+  display:block;
+  margin:0 auto;
+}
 .icon-btn {
   border:none;
   background: var(--panel);
@@ -174,6 +179,7 @@ body { background: var(--bg); color: var(--text); }
     border-bottom: none;
     padding: 8px 12px;
   }
+  .brand-bar{ border-bottom: none; }
   .layout { grid-template-columns: 1fr; }
   .side {
     display:block;


### PR DESCRIPTION
## Summary
- Center the mobile top bar logo by making it a block element with auto margins.
- Remove the brand bar's bottom border on small screens to eliminate the line under the logo.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f6e5c201883309b81f2da6c0f17f6