### PR TITLE
Add finish navigation to completed modules

### DIFF
--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -410,7 +410,8 @@ function fireProgressEvent(payload){
         <div class="flashcard-actions"><button class="btn primary" id="np-unlock">Unlock next phrase</button></div>`;
       viewEl.querySelector('#np-unlock').addEventListener('click',unlockNext);
     } else {
-      viewEl.innerHTML=`<div class="flashcard-progress muted">No new phrases available today. Come back tomorrow.</div>`;
+      viewEl.innerHTML=`<div class="flashcard-progress muted" style="margin-bottom:8px;">No new phrases available today. Come back tomorrow.</div>
+        <div class="flashcard-actions"><a class="btn nav-btn" href="#/home">Finish</a></div>`;
       window.dispatchEvent(new CustomEvent('fc:module-complete',{ detail:{ module:'new' }}));
     }
   }

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -397,7 +397,7 @@ function fireProgressEvent(payload){
         <div class="tm-result tm-correct" style="margin-top:8px;">${correct} / ${total} correct (${pct}%)</div>
         ${wrong.length ? `<div class="tm-mismatch"><div class="tm-label">Incorrect</div><ul class="tm-anslist">${list}</ul></div>` : ''}
         <div class="flashcard-actions" style="flex-direction:column; gap:6px;">
-          <a class="btn nav-btn" href="#/home">Home</a>
+          <a class="btn nav-btn" href="#/home">Finish</a>
         </div>
         <div class="flashcard-progress muted">Nice work!</div>
       </div>`;


### PR DESCRIPTION
## Summary
- Show a Finish button when no more new phrases are available for the day
- Change test completion screen to use a Finish button linking back to dashboard

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f746e26708330b19edf2bd555d520