### PR TITLE
Track days per user

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
       const toRemove = [];
       for (let i = 0; i < localStorage.length; i++) {
         const k = localStorage.key(i);
-        if (/^progress_/.test(k) || /^np_daily_/.test(k) || k === "tm_attempts_v1") toRemove.push(k);
+        if (/^progress_/.test(k) || /^np_daily_/.test(k) || k === "tm_attempts_v1" || k === 'tm_day_start' || k === 'tm_day_count' || k === 'tm_last_increment' || k === 'tm_start_date') toRemove.push(k);
       }
       toRemove.forEach(k => localStorage.removeItem(k));
     }
@@ -154,7 +154,7 @@
       const data = {};
       for (let i = 0; i < localStorage.length; i++) {
         const k = localStorage.key(i);
-        if (/^progress_/.test(k) || /^np_daily_/.test(k) || k === "tm_attempts_v1") data[k] = localStorage.getItem(k);
+        if (/^progress_/.test(k) || /^np_daily_/.test(k) || k === "tm_attempts_v1" || k === 'tm_day_start' || k === 'tm_day_count' || k === 'tm_last_increment') data[k] = localStorage.getItem(k);
       }
       await setDoc(doc(db, "progress", auth.currentUser.uid), data);
     }

--- a/js/app.js
+++ b/js/app.js
@@ -14,7 +14,9 @@ const STORAGE = {
 const LS_PROGRESS_PREFIX = 'progress_';
 const LS_NEW_DAILY_PREFIX = 'np_daily_';
 const LS_ATTEMPTS_KEY = 'tm_attempts_v1';
-const LS_START_KEY = 'tm_start_date';
+const LS_DAY_START = 'tm_day_start';
+const LS_DAY_COUNT = 'tm_day_count';
+const LS_DAY_LAST  = 'tm_last_increment';
 const SCORE_WINDOW = 10;
 const LS_TEST_SESSION = 'tm_session';
 const SCORE_COOLDOWN_MS = 60 * 60 * 1000; // 60 minutes
@@ -222,15 +224,21 @@ function accuracyHue(p){
   const clamped=Math.max(0,Math.min(100,p));
   return Math.round((clamped/100)*120);
 }
-function getDayNumber(){
+function tickDay(){
   const today = todayKey();
-  let start = localStorage.getItem(LS_START_KEY);
+  let start = localStorage.getItem(LS_DAY_START);
   if(!start){
-    localStorage.setItem(LS_START_KEY, today);
-    return 1;
+    localStorage.setItem(LS_DAY_START, today);
   }
-  const diff = Math.floor((new Date(today) - new Date(start))/86400000);
-  return diff + 1;
+  const last = localStorage.getItem(LS_DAY_LAST);
+  if(last !== today){
+    const count = parseInt(localStorage.getItem(LS_DAY_COUNT) || '0', 10) + 1;
+    localStorage.setItem(LS_DAY_COUNT, String(count));
+    localStorage.setItem(LS_DAY_LAST, today);
+  }
+}
+function getDayNumber(){
+  return parseInt(localStorage.getItem(LS_DAY_COUNT) || '0', 10);
 }
 async function loadDeckRows(deckId){
   const dk = deckId || deckKeyFromState();

--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -52,18 +52,6 @@ function fireProgressEvent(payload){
       .replace(/\s+/g,' ').trim();
     return out;
   }
-  function currentDay(deckId){
-    const today = new Date();
-    today.setHours(0,0,0,0);
-    const todayKey = today.toISOString().slice(0,10);
-    const start = localStorage.getItem('tm_start_date');
-    if (!start) {
-      localStorage.setItem('tm_start_date', todayKey);
-      return 1;
-    }
-    const diff = Math.floor((new Date(todayKey) - new Date(start)) / 86400000);
-    return diff + 1;
-  }
   function levenshtein(a,b){
     const m=a.length,n=b.length; if(!m) return n; if(!n) return m;
     const prev=new Array(n+1),cur=new Array(n+1);
@@ -188,7 +176,7 @@ function fireProgressEvent(payload){
     viewEl=host.querySelector('#np-root');
 
     const deckId = dk;
-    host.querySelector('#np-day').textContent=currentDay(deckId);
+    host.querySelector('#np-day').textContent=getDayNumber();
 
     (function migrateDailyIfNeeded(){
       const canonical = dailyKey;
@@ -375,6 +363,7 @@ function fireProgressEvent(payload){
         if(ok){
           markSeenNow(c.id);
           bumpDailyUsed();
+          tickDay();
           window.fcSaveCloud && window.fcSaveCloud();
           fireProgressEvent({ type: 'introduced', id: c.id });
           const deckId = dk;

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -85,8 +85,6 @@ function fireProgressEvent(payload){
   // Test Mode – review only. Route: #/test
 
   /* ---------- Constants & state ---------- */
-  const LS_START_KEY = 'tm_start_date';
-
   let container = null;
   let deck = [];
   let idx = 0;
@@ -96,22 +94,6 @@ function fireProgressEvent(payload){
   let seenThisSession = new Set();
 
   /* ---------- Small helpers ---------- */
-  function todayKey() {
-    const d = new Date();
-    d.setHours(0,0,0,0);
-    return d.toISOString().slice(0,10);
-  }
-
-  function getDayNumber() {
-    const today = todayKey();
-    let start = localStorage.getItem(LS_START_KEY);
-    if (!start) {
-      localStorage.setItem(LS_START_KEY, today);
-      return 1;
-    }
-    const diff = Math.floor((new Date(today) - new Date(start)) / 86400000);
-    return diff + 1;
-  }
 
   function shuffle(arr) {
     const a = arr.slice();
@@ -276,6 +258,7 @@ function fireProgressEvent(payload){
     const c = deck[idx];
     const val = container.querySelector('#tm-answer').value || '';
     const pass = !skip && equalsLoose(val, c.front);
+    if (pass) tickDay();
     logAttempt(c.id, pass, { forceNoScore: practiceMode });
     fireProgressEvent({ type:'attempt', id: c.id, pass });
     if (pass) {
@@ -336,6 +319,7 @@ function fireProgressEvent(payload){
       function submit(){
         const val = inp.value || '';
         const ok = equalsLoose(val, card.front);
+        if (ok) tickDay();
         const counted = logAttempt(card.id, ok, { forceNoScore: practiceMode });
         fireProgressEvent({ type:'attempt', id: card.id, pass: ok });
         if (ok) {


### PR DESCRIPTION
## Summary
- replace global start-date counter with per-user day tracking
- sync day tracking keys to Firestore progress data
- increment day count when a user completes a new phrase or test question

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f70fb87b08330b6d7a9fbd11f1f40