### PR TITLE
Revamp brand bar and hamburger menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,11 @@
 
   <!-- Mobile topbar -->
   <header class="topbar">
-    <button id="menuToggle" class="icon-btn" aria-label="Toggle menu">☰</button>
+    <button id="menuToggle" class="hamburger" aria-label="Toggle menu">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
     <img src="media/image/welshlogo.png" alt="Draig logo" class="topbar-logo">
     <div class="day-display"></div>
   </header>
@@ -46,8 +50,8 @@
     <a href="#/home" aria-label="Siarad Home" class="brand-link">
       <svg width="36" height="36" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         <circle cx="18" cy="18" r="18" fill="#C8102E" />
-        <rect x="6" y="9" width="24" height="18" rx="4" fill="#ffffff" />
-        <path d="M26 23 L30 27 L26 27 Z" fill="#ffffff" />
+        <rect x="7" y="8" width="22" height="15" rx="7" fill="#ffffff" />
+        <path d="M23 20 L29 24 L23 24 Z" fill="#ffffff" />
       </svg>
       <span class="brand-name">Siarad</span>
     </a>

--- a/styles/base.css
+++ b/styles/base.css
@@ -139,7 +139,8 @@ body { background: var(--bg); color: var(--text); }
   height:56px;
   display:flex;
   align-items:center;
-  padding:0 24px;
+  justify-content:center;
+  padding:0;
 }
 .brand-link{
   display:flex;
@@ -162,11 +163,34 @@ body { background: var(--bg); color: var(--text); }
   display:block;
   margin:0 auto;
 }
-.icon-btn {
+
+.hamburger {
+  background:none;
   border:none;
-  background: var(--panel);
-  color: var(--text);
-  border-radius:10px; padding:4px; cursor:pointer;
+  padding:0;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+  align-items:center;
+  gap:5px;
+  width:24px;
+  height:24px;
+  cursor:pointer;
+}
+
+.hamburger span {
+  display:block;
+  width:18px;
+  height:2px;
+  background:#ffffff;
+  border-radius:1px;
+  transition:background .18s ease;
+}
+
+.hamburger:hover span,
+.hamburger:focus span,
+.hamburger:active span {
+  background:#CFEEDA;
 }
 @media (max-width: 768px) {
   .navbar{ display:none; }
@@ -179,7 +203,7 @@ body { background: var(--bg); color: var(--text); }
     border-bottom: none;
     padding: 8px 12px;
   }
-  .topbar .icon-btn{ justify-self: start; }
+  .topbar .hamburger{ justify-self: start; }
   .topbar-logo{ grid-column: 2; }
   .topbar .day-display{ justify-self: end; }
   .brand-bar{ border-bottom: none; }


### PR DESCRIPTION
## Summary
- Replace brand bar graphic with rounded white speech bubble on red circle
- Center logo in brand bar across screen sizes
- Swap square menu button for borderless hamburger with hover color change

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f7eb4482483309d2177f9535ff9f7