### PR TITLE
Track streak only on activity and sync to cloud

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
       const toRemove = [];
       for (let i = 0; i < localStorage.length; i++) {
         const k = localStorage.key(i);
-        if (/^progress_/.test(k) || /^np_daily_/.test(k) || k === "tm_attempts_v1" || k === 'tm_day_start' || k === 'tm_day_count' || k === 'tm_last_increment' || k === 'tm_start_date') toRemove.push(k);
+        if (/^progress_/.test(k) || /^np_daily_/.test(k) || k === "tm_attempts_v1" || k === 'tm_day_count' || k === 'tm_last_increment') toRemove.push(k);
       }
       toRemove.forEach(k => localStorage.removeItem(k));
     }
@@ -158,7 +158,7 @@
       const data = {};
       for (let i = 0; i < localStorage.length; i++) {
         const k = localStorage.key(i);
-        if (/^progress_/.test(k) || /^np_daily_/.test(k) || k === "tm_attempts_v1" || k === 'tm_day_start' || k === 'tm_day_count' || k === 'tm_last_increment') data[k] = localStorage.getItem(k);
+        if (/^progress_/.test(k) || /^np_daily_/.test(k) || k === "tm_attempts_v1" || k === 'tm_day_count' || k === 'tm_last_increment') data[k] = localStorage.getItem(k);
       }
       await setDoc(doc(db, "progress", auth.currentUser.uid), data);
     }

--- a/js/app.js
+++ b/js/app.js
@@ -14,7 +14,6 @@ const STORAGE = {
 const LS_PROGRESS_PREFIX = 'progress_';
 const LS_NEW_DAILY_PREFIX = 'np_daily_';
 const LS_ATTEMPTS_KEY = 'tm_attempts_v1';
-const LS_DAY_START = 'tm_day_start';
 const LS_DAY_COUNT = 'tm_day_count';
 const LS_DAY_LAST  = 'tm_last_increment';
 const SCORE_WINDOW = 10;
@@ -226,15 +225,12 @@ function accuracyHue(p){
 }
 function tickDay(){
   const today = todayKey();
-  let start = localStorage.getItem(LS_DAY_START);
-  if(!start){
-    localStorage.setItem(LS_DAY_START, today);
-  }
   const last = localStorage.getItem(LS_DAY_LAST);
   if(last !== today){
     const count = parseInt(localStorage.getItem(LS_DAY_COUNT) || '0', 10) + 1;
     localStorage.setItem(LS_DAY_COUNT, String(count));
     localStorage.setItem(LS_DAY_LAST, today);
+    window.fcSaveCloud && window.fcSaveCloud();
   }
 }
 function getDayNumber(){

--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -364,7 +364,6 @@ function fireProgressEvent(payload){
           markSeenNow(c.id);
           bumpDailyUsed();
           tickDay();
-          window.fcSaveCloud && window.fcSaveCloud();
           fireProgressEvent({ type: 'introduced', id: c.id });
           const deckId = dk;
           const prog = loadProgress(deckId);


### PR DESCRIPTION
## Summary
- Simplify day-counter logic to increment only once per day on activity and save to cloud
- Remove unused start-date fields from local and cloud persistence
- Streamline new phrase completion to rely on shared day-ticking logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f8ef992dc833089c459d9c7be4129