### PR TITLE
Make learned phrases table responsive on mobile

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -415,13 +415,13 @@ async function renderLearned(){
   data.forEach(r=>{
     const tr=document.createElement('tr');
     tr.innerHTML=`
-      <td>${escapeHTML(r.front)}</td>
-      <td>${escapeHTML(r.back)}</td>
-      <td>${r.status}</td>
-      <td><div class="progress"><i style="--w:${r.acc}%"></i></div> ${r.acc}%</td>
-      <td>${r.tries}</td>
-      <td>${escapeHTML(r.tags)}</td>
-      <td class="actions"><a class="btn" href="#/review?card=${encodeURIComponent(r.id)}">Study</a> <a class="btn" href="#/test?card=${encodeURIComponent(r.id)}">Test</a></td>`;
+      <td data-label="Phrase (Welsh)">${escapeHTML(r.front)}</td>
+      <td data-label="Meaning (English)">${escapeHTML(r.back)}</td>
+      <td data-label="Status">${r.status}</td>
+      <td data-label="Accuracy"><div class="progress"><i style="--w:${r.acc}%"></i></div> ${r.acc}%</td>
+      <td data-label="Last attempts">${r.tries}</td>
+      <td data-label="Tags">${escapeHTML(r.tags)}</td>
+      <td data-label="Actions" class="actions"><a class="btn" href="#/review?card=${encodeURIComponent(r.id)}">Study</a> <a class="btn" href="#/test?card=${encodeURIComponent(r.id)}">Test</a></td>`;
     tbody.appendChild(tr);
   });
   wrap.appendChild(table);

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -84,6 +84,16 @@
 
 /* Learned phrases table */
 .phrase-table{ width:100%; border-collapse:collapse; margin-top:16px; font-size:14px; }
-.phrase-table th, .phrase-table td{ padding:8px 10px; border-bottom:1px solid var(--border); text-align:left; }
+.phrase-table th, .phrase-table td{ padding:8px 10px; border-bottom:1px solid var(--border); text-align:left; word-break:break-word; }
 .phrase-table th{ background: var(--panel-2); font-weight:700; }
 .phrase-table td.actions{ display:flex; gap:6px; }
+
+/* Stack table rows on small screens so content fits within width */
+@media (max-width: 600px){
+  .phrase-table thead{ display:none; }
+  .phrase-table tr{ display:block; border:1px solid var(--border); border-radius:8px; margin-bottom:12px; }
+  .phrase-table td{ display:block; border:none; padding:8px 10px; }
+  .phrase-table td + td{ border-top:1px solid var(--border); }
+  .phrase-table td::before{ content: attr(data-label); display:block; font-weight:700; color:var(--muted); margin-bottom:4px; }
+  .phrase-table td.actions{ display:flex; gap:6px; }
+}


### PR DESCRIPTION
## Summary
- Add data-label attributes to learned phrase cells so rows can stack vertically.
- Introduce mobile CSS that hides the header, stacks table rows, and shows labels for each field, preventing horizontal overflow.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9b2e2cf08330af77379711f07ce7