### PR TITLE
Ensure day counter reflects current study day

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,15 +87,6 @@
   <!-- app/router last -->
   <script src="js/app.js" defer></script>
 
-  <!-- show current day -->
-  <script>
-    document.addEventListener("DOMContentLoaded", () => {
-      document.querySelectorAll(".day-display").forEach(el => {
-        el.textContent = new Date().getDate();
-      });
-    });
-  </script>
-
   <!-- tiny error banner (unchanged) -->
   <script>
     (function () {

--- a/js/app.js
+++ b/js/app.js
@@ -768,6 +768,10 @@ function colorStatCard(el,pct=50){
 
 /* ---------- Boot ---------- */
 window.addEventListener('DOMContentLoaded',()=>{
+  tickDay();
+  document.querySelectorAll('.day-display').forEach(el => {
+    el.textContent = getDayNumber();
+  });
   initDeckPicker();
   initMobileMenu();
   render();


### PR DESCRIPTION
## Summary
- Increment day counter on startup and update all `.day-display` elements to the current study day.
- Remove obsolete inline script that set a fixed calendar date.

## Testing
- `node --check js/app.js`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9b8687a08330af5579aa8147bf38