### PR TITLE
Fix quiz counter to ignore cooled-down quiz items

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -646,7 +646,7 @@ async function renderPhraseDashboard(){
   const used    = daily.used    || 0;
   const newToday = Math.max(0, allowed - used);
 
-  const quizCount = activeRows.length;
+  const quizCount = await fcGetTestQueueCount();
   const learned   = Object.keys(seen).length;
   const deckPct   = rows.length ? Math.round((learned/rows.length)*100) : 0;
 

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -2002,7 +2002,7 @@ async function renderPhraseDashboard(){
   const used    = daily.used    || 0;
   const newToday = Math.max(0, allowed - used);
 
-  const quizCount = activeRows.length;
+  const quizCount = await fcGetTestQueueCount();
   const learned   = Object.keys(seen).length;
   const deckPct   = rows.length ? Math.round((learned/rows.length)*100) : 0;
 


### PR DESCRIPTION
## Summary
- Use `fcGetTestQueueCount` for quiz badge on phrase dashboard
- Ensure quiz counter ignores cards still in 60-minute cooldown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fadd0d29c83309ce948d75605cff7