### PR TITLE
feat: add icon tabs to words dashboard

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -575,12 +575,22 @@ async function renderHome(){
 
 async function renderWordsDashboard(qs){
   const tab=(qs&&qs.get('tab'))||'days';
-  const tabs=['days','months','numbers','colours','animals'];
+  const tabs=[
+    {key:'days',label:'Days',icon:'Days'},
+    {key:'months',label:'Months',icon:'Months'},
+    {key:'numbers',label:'Numbers',icon:'Numbers'},
+    {key:'colours',label:'Colours',icon:'Colours'},
+    {key:'animals',label:'Animals',icon:'Animals'}
+  ];
   const wrap=document.createElement('div');
   wrap.innerHTML=`
     <h1 class="h1">Words</h1>
     <nav class="tabs">
-      ${tabs.map(t=>`<a href="#/words?tab=${t}" class="${t===tab?'active':''}">${t.charAt(0).toUpperCase()+t.slice(1)}</a>`).join('')}
+      ${tabs.map(t=>`
+        <a href="#/words?tab=${t.key}" class="tab ${t.key===tab?'active':''}">
+          <div class="bubble"><img class="icon" src="media/icons/${t.icon}.png" alt="${t.label} icon"></div>
+          <div class="label">${t.label}</div>
+        </a>`).join('')}
     </nav>
     <div class="panel-white" style="margin-top:20px">
       <div class="panel-title">${tab.charAt(0).toUpperCase()+tab.slice(1)}</div>

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -1931,12 +1931,22 @@ async function renderHome(){
 
 async function renderWordsDashboard(qs){
   const tab=(qs&&qs.get('tab'))||'days';
-  const tabs=['days','months','numbers','colours','animals'];
+  const tabs=[
+    {key:'days',label:'Days',icon:'Days'},
+    {key:'months',label:'Months',icon:'Months'},
+    {key:'numbers',label:'Numbers',icon:'Numbers'},
+    {key:'colours',label:'Colours',icon:'Colours'},
+    {key:'animals',label:'Animals',icon:'Animals'}
+  ];
   const wrap=document.createElement('div');
   wrap.innerHTML=`
     <h1 class="h1">Words</h1>
     <nav class="tabs">
-      ${tabs.map(t=>`<a href="#/words?tab=${t}" class="${t===tab?'active':''}">${t.charAt(0).toUpperCase()+t.slice(1)}</a>`).join('')}
+      ${tabs.map(t=>`
+        <a href="#/words?tab=${t.key}" class="tab ${t.key===tab?'active':''}">
+          <div class="bubble"><img class="icon" src="media/icons/${t.icon}.png" alt="${t.label} icon"></div>
+          <div class="label">${t.label}</div>
+        </a>`).join('')}
     </nav>
     <div class="panel-white" style="margin-top:20px">
       <div class="panel-title">${tab.charAt(0).toUpperCase()+tab.slice(1)}</div>

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -53,6 +53,16 @@
 
 .skill:hover .bubble{ border-color: var(--welsh-red); transform: translateY(-1px); transition: transform .12s ease; }
 
+.tabs{ display:flex; gap:12px; }
+.tabs .tab{ text-align:center; text-decoration:none; color:inherit; }
+.tabs .bubble{
+  width:60px; aspect-ratio:1; border-radius:50%;
+  background:#fff; border:2px solid var(--border); display:grid; place-items:center;
+}
+.tabs .tab.active .bubble{ border-color: var(--welsh-red); }
+.tabs .icon{ width:70%; height:70%; object-fit:contain; }
+.tabs .label{ margin-top:6px; font-size:12px; font-weight:700; }
+
 .duo-cta{ margin-top: 16px; display:flex; gap:12px; }
 .duo-cta .btn.primary{ background: var(--welsh-red); color:#fff; border-color: var(--welsh-red); }
 .duo-cta .btn.primary:hover{ filter: saturate(1.08); }

--- a/styles/main.css
+++ b/styles/main.css
@@ -306,6 +306,16 @@ body { background: #ffffff !important; color: #0f1117 !important; }
 
 .skill:hover .bubble{ border-color: var(--welsh-red); transform: translateY(-1px); transition: transform .12s ease; }
 
+.tabs{ display:flex; gap:12px; }
+.tabs .tab{ text-align:center; text-decoration:none; color:inherit; }
+.tabs .bubble{
+  width:60px; aspect-ratio:1; border-radius:50%;
+  background:#fff; border:2px solid var(--border); display:grid; place-items:center;
+}
+.tabs .tab.active .bubble{ border-color: var(--welsh-red); }
+.tabs .icon{ width:70%; height:70%; object-fit:contain; }
+.tabs .label{ margin-top:6px; font-size:12px; font-weight:700; }
+
 .duo-cta{ margin-top: 16px; display:flex; gap:12px; }
 .duo-cta .btn.primary{ background: var(--welsh-red); color:#fff; border-color: var(--welsh-red); }
 .duo-cta .btn.primary:hover{ filter: saturate(1.08); }


### PR DESCRIPTION
## Summary
- show Days, Months, Numbers, Colours, Animals as circular icon tabs on the Words dashboard
- style new tabs with bubble icons and active state border

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a019c20bc883308bbd01616b126378