### PR TITLE
Refactor dashboards with consistent page header

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,6 @@
       <span></span>
     </button>
     <a href="#/home"><img src="media/image/welshflag.png" alt="Siarad logo" class="topbar-logo"></a>
-    <div class="day-display"></div>
   </header>
 
   <!-- Brand bar -->
@@ -58,6 +57,14 @@
   <div class="layout">
     <!-- Sidebar (mobile drawer only) -->
     <aside class="side">
+      <div class="side-controls">
+        <img src="media/image/welshflag.png" alt="Siarad logo" class="side-logo">
+        <select id="deckSelectSide" class="deck-select" aria-label="Switch deck"></select>
+        <div class="side-chips">
+          <span class="ph-chip"><span class="day-display"></span></span>
+          <span class="ph-chip" id="dueDisplay">0 due</span>
+        </div>
+      </div>
       <nav class="nav" aria-label="Primary">
         <a href="#/home" data-route="home" class="active">Dashboard</a>
         <a href="#/learned" data-route="learned">Learned Phrases</a>

--- a/styles/main.css
+++ b/styles/main.css
@@ -259,21 +259,28 @@ body { background: #ffffff !important; color: #0f1117 !important; }
 
 .skills-grid{
   display:grid;
-  justify-content:center;
 }
 .skills-grid.grid-3{
-  grid-template-columns: repeat(3,160px);
-  gap:28px; align-items:start;
+  grid-template-columns: repeat(4,1fr);
+  gap:32px;
+  align-items:start;
 }
 .skills-grid.grid-2{
-  grid-template-columns: repeat(2,160px);
-  gap:16px; align-items:start;
+  grid-template-columns: repeat(3,1fr);
+  gap:24px;
+  align-items:start;
 }
-
+@media (max-width: 920px){
+  .skills-grid.grid-3{
+    grid-template-columns: repeat(3,1fr);
+    gap:24px;
+  }
+}
 @media (max-width: 600px){
   .skills-grid.grid-3,
   .skills-grid.grid-2{
-    grid-template-columns: 160px;
+    grid-template-columns: repeat(2,1fr);
+    gap:16px;
   }
 }
 
@@ -436,3 +443,88 @@ body { background: #ffffff !important; color: #0f1117 !important; }
 
 /* Hide any legacy flip button */
 #flipBtn { display: none !important; }
+
+/* Page header */
+.page-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: grid;
+  gap: 8px;
+  background: #fff;
+  padding: 32px;
+  height: 112px;
+}
+.page-header .ph-main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.page-header .ph-left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.page-header .ph-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+.page-header .ph-title {
+  font-size: 34px;
+  font-weight: 700;
+  letter-spacing: -1%;
+  color: #0F1D13;
+  margin: 0;
+}
+.ph-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.ph-chip {
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 9999px;
+  background: #E9F5ED;
+  color: #1C8E4A;
+}
+.play-all {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: #C8102E;
+  border: none;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+.play-all img {
+  width: 24px;
+  height: 24px;
+}
+
+@media (max-width: 768px) {
+  .page-header {
+    padding: 20px;
+    height: 96px;
+  }
+}
+
+.side-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.side-controls .side-logo {
+  width: 48px;
+  height: 48px;
+}
+.side-controls .side-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}


### PR DESCRIPTION
## Summary
- Introduce reusable `buildPageHeader` and responsive CSS for a fixed header with chips and play-all button
- Use the new header on Dashboard, Phrases, and Words screens and update due count & play-all actions
- Move deck selector and day/due chips to mobile side menu and adjust grids for consistent spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a02800d9ac8330acf675cd4420c425