### PR TITLE
Streamline navigation and add status pills

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
   <header class="navbar" role="banner">
     <div class="nav-left">
       <a href="#/home" class="brand siarad"><img src="media/image/welshflag.png" alt="Siarad logo"></a>
-      <select id="deckSelect" class="deck-select" aria-label="Switch deck"></select>
       <nav class="nav nav-horizontal" aria-label="Primary">
         <a href="#/home" data-route="home">Dashboard</a>
         <a href="#/learned" data-route="learned">Learned Phrases</a>
@@ -59,10 +58,10 @@
     <aside class="side">
       <div class="side-controls">
         <img src="media/image/welshflag.png" alt="Siarad logo" class="side-logo">
-        <select id="deckSelectSide" class="deck-select" aria-label="Switch deck"></select>
-        <div class="side-chips">
-          <span class="ph-chip"><span class="day-display"></span></span>
-          <span class="ph-chip" id="dueDisplay">0 due</span>
+        <select id="deckSelect" class="deck-select" aria-label="Switch deck"></select>
+        <div class="status-pills">
+          <span class="status-pill gold" id="newDisplay">0 new</span>
+          <span class="status-pill green" id="dueDisplay">0 due</span>
         </div>
       </div>
       <nav class="nav" aria-label="Primary">

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -42,10 +42,10 @@
 .skill .emoji{ font-size:52px; line-height:1; }
 .skill .icon{ width:100%; height:100%; object-fit:contain; }
 .skill .badge{
-  position:absolute; top:-8px; right:-8px;
-  min-width: 30px; height:30px; padding:0 10px;
+  position:absolute; top:-6px; right:-6px;
+  min-width: 20px; height:20px; padding:0 6px;
   border-radius: 999px; display:grid; place-items:center;
-  background: var(--welsh-green); color:#fff; font-weight:800; font-size:12px;
+  background: var(--welsh-green); color:#fff; font-weight:800; font-size:9px;
   box-shadow: 0 8px 22px rgba(0,0,0,.15);
 }
 .skill .label{ margin-top:10px; font-weight:800; }

--- a/styles/main.css
+++ b/styles/main.css
@@ -302,10 +302,10 @@ body { background: #ffffff !important; color: #0f1117 !important; }
 .skill .emoji{ font-size:52px; line-height:1; }
 .skill .icon{ width:100%; height:100%; object-fit:contain; }
 .skill .badge{
-  position:absolute; top:-8px; right:-8px;
-  min-width: 30px; height:30px; padding:0 10px;
+  position:absolute; top:-6px; right:-6px;
+  min-width: 20px; height:20px; padding:0 6px;
   border-radius: 999px; display:grid; place-items:center;
-  background: var(--welsh-green); color:#fff; font-weight:800; font-size:12px;
+  background: var(--welsh-green); color:#fff; font-weight:800; font-size:9px;
   box-shadow: 0 8px 22px rgba(0,0,0,.15);
 }
 .skill .label{ margin-top:10px; font-weight:800; }
@@ -476,7 +476,8 @@ body { background: #ffffff !important; color: #0f1117 !important; }
   font-size: 34px;
   font-weight: 700;
   letter-spacing: -1%;
-  color: #0F1D13;
+  color: #C8102E;
+  font-family: 'Poppins','Nunito',sans-serif;
   margin: 0;
 }
 .ph-chips {
@@ -523,8 +524,26 @@ body { background: #ffffff !important; color: #0f1117 !important; }
   width: 48px;
   height: 48px;
 }
-.side-controls .side-chips {
+.side-controls .status-pills {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+.status-pill {
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: 9999px;
+  font-weight: 700;
+  display: inline-block;
+}
+
+.status-pill.gold {
+  background: #FFD447;
+  color: #0F1D13;
+}
+
+.status-pill.green {
+  background: var(--welsh-green);
+  color: #fff;
 }


### PR DESCRIPTION
## Summary
- Remove deck/day info from page headers and keep bold red section titles
- Move deck selector into sidebar and show gold/green new vs. due status pills
- Shrink skill notification badges for a lighter look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a03d0a19748330bf859ecf9d682deb