### PR TITLE
Fix due counter to use test queue

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -92,8 +92,7 @@ async function updateStatusPills(){
     return {status};
   });
   const strugglingCount = enriched.filter(x=>x.status==='Struggling').length;
-  const needsCount      = enriched.filter(x=>x.status==='Needs review').length;
-  const reviewDue       = strugglingCount + needsCount;
+  const reviewDue       = await fcGetTestQueueCount();
   getDailyNewAllowance(deckId, strugglingCount, unseenCount);
   const daily   = JSON.parse(localStorage.getItem(dailyKey) || '{}');
   const allowed = daily.allowed || 0;
@@ -671,8 +670,7 @@ async function renderPhraseDashboard(){
     return { ...r, acc, status };
   });
   const strugglingCount = enriched.filter(x=>x.status==='Struggling').length;
-  const needsCount      = enriched.filter(x=>x.status==='Needs review').length;
-  const reviewDue       = strugglingCount + needsCount;
+  const reviewDue       = await fcGetTestQueueCount();
 
   // new phrases allowance
   getDailyNewAllowance(deckId, strugglingCount, unseenCount);
@@ -681,7 +679,7 @@ async function renderPhraseDashboard(){
   const used    = daily.used    || 0;
   const newToday = Math.max(0, allowed - used);
 
-  const quizCount = await fcGetTestQueueCount();
+  const quizCount = reviewDue;
   const learned   = Object.keys(seen).length;
   const deckPct   = rows.length ? Math.round((learned/rows.length)*100) : 0;
 


### PR DESCRIPTION
## Summary
- calculate due count using the test queue
- refresh status pills after progress updates

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a048ca7a18833099b111272a381486