### PR TITLE
Restore desktop login and deck selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <header class="navbar" role="banner">
     <div class="nav-left">
       <a href="#/home" class="brand siarad"><img src="media/image/welshflag.png" alt="Siarad logo"></a>
+      <select id="deckSelectTop" class="deck-select" aria-label="Switch deck"></select>
       <nav class="nav nav-horizontal" aria-label="Primary">
         <a href="#/home" data-route="home">Dashboard</a>
         <a href="#/learned" data-route="learned">Learned Phrases</a>
@@ -26,9 +27,10 @@
         <a href="#/settings" data-route="settings">Settings</a>
       </nav>
     </div>
-      <div class="nav-right">
-        <div id="dayDisplay" class="day-display"></div>
-      </div>
+    <div class="nav-right">
+      <div id="dayDisplay" class="day-display"></div>
+      <div class="auth-box"></div>
+    </div>
   </header>
 
   <!-- Mobile topbar -->

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -1411,8 +1411,9 @@ function setActiveDeck(id) {
   if (!DECKS.some(d => d.id === id)) return;
   STATE.activeDeckId = id;
   localStorage.setItem(STORAGE.deck, id);
-  const sel = document.getElementById('deckSelect');
-  if (sel) sel.value = id;
+  document.querySelectorAll('.deck-select').forEach(sel => {
+    sel.value = id;
+  });
   render();
 }
 
@@ -1463,19 +1464,19 @@ async function updateStatusPills(){
 
 /* ---------- Deck picker ---------- */
 function initDeckPicker() {
-  const sel = document.getElementById('deckSelect');
-  if (!sel) return;
-  sel.innerHTML = '';
-  DECKS.forEach(d => {
-    const prog = loadProgress(d.id);
-    const count = Object.keys(prog.seen || {}).length;
-    const opt = document.createElement('option');
-    opt.value = d.id;
-    opt.textContent = `${d.name} (${count})`;
-    if (d.id === STATE.activeDeckId) opt.selected = true;
-    sel.appendChild(opt);
+  document.querySelectorAll('.deck-select').forEach(sel => {
+    sel.innerHTML = '';
+    DECKS.forEach(d => {
+      const prog = loadProgress(d.id);
+      const count = Object.keys(prog.seen || {}).length;
+      const opt = document.createElement('option');
+      opt.value = d.id;
+      opt.textContent = `${d.name} (${count})`;
+      if (d.id === STATE.activeDeckId) opt.selected = true;
+      sel.appendChild(opt);
+    });
+    sel.addEventListener('change', e => setActiveDeck(e.target.value));
   });
-  sel.addEventListener('change', e => setActiveDeck(e.target.value));
 }
 
 /* ---------- Theme (locked to light) ---------- */


### PR DESCRIPTION
## Summary
- Add deck selector and login button to desktop navbar while keeping mobile menu unchanged.
- Update deck picker logic to support multiple deck-select elements.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a05a37c8fc83309c7560b1ded6fe5e