### PR TITLE
Restore Google login in navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,9 @@
     </div>
     <div class="nav-right">
       <div id="dayDisplay" class="day-display"></div>
-      <div class="auth-box"></div>
+      <div class="auth-box">
+        <button class="auth-btn btn"></button>
+      </div>
     </div>
   </header>
 
@@ -72,7 +74,12 @@
         <a href="#/decks" data-route="decks">Custom Phrases</a>
         <a href="#/settings" data-route="settings">Settings</a>
       </nav>
-      <div class="side-footer"></div>
+      <div class="side-footer">
+        <div class="auth-box">
+          <div class="auth-status muted"></div>
+          <button class="auth-btn btn"></button>
+        </div>
+      </div>
     </aside>
 
     <!-- Main view -->


### PR DESCRIPTION
## Summary
- Ensure a Google sign-in button is always present beside the day counter on desktop
- Add Google sign-in controls to the bottom of the mobile menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a062cd673083309a78b94bb32ff393