### PR TITLE
Adjust daily new allowance based on struggling phrases

### DIFF
--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -368,7 +368,11 @@ async function renderNewPhrase(){
     unseenCards.sort(sortByCourseOrder);
 
     // Daily allowance
-    const daily = getDailyNewAllowance(dk, 0, unseenCards.length);
+    const prev = loadNewDaily(dk);
+    const dayKey = todayKey();
+    const usedToday = prev.date === dayKey ? (prev.used || 0) : 0;
+    const daily = getDailyNewAllowance(unseenCards.length, usedToday, 0);
+    saveNewDaily(dk, { date: dayKey, ...daily });
     queue = unseenCards.slice(0, Math.max(0, (daily.allowed || 0) - (daily.used || 0)));
 
     idx = 0; step = STEPS.WELSH;


### PR DESCRIPTION
## Summary
- add STRUGGLE_CAP and compute daily new phrase allowance from `SETTINGS.newPerDay`
- scale allowance down as struggling phrases rise and clamp to valid range
- update calls to persist and display the recalculated allowance

## Testing
- `node --check js/app.js`
- `node --check js/newPhrase.js`
- `node --check js/bundle.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a06c07f8148330a178281412654d31