### PR TITLE
Wire Google login button to auth

### DIFF
--- a/js/firebase.js
+++ b/js/firebase.js
@@ -89,9 +89,13 @@ if (firebaseConfig) {
     });
     document.querySelectorAll(".auth-btn").forEach(btn => {
       btn.textContent = user ? "Log Out" : "Login with Google";
-      btn.onclick = user ? signOutUser : signInWithGoogle;
     });
   }
   onAuthStateChanged(auth, (user) => renderAuthUI(user));
-  document.addEventListener("DOMContentLoaded", () => renderAuthUI(auth.currentUser));
+  document.addEventListener("DOMContentLoaded", () => {
+    renderAuthUI(auth.currentUser);
+    document.querySelectorAll(".auth-btn").forEach(btn => {
+      btn.addEventListener("click", () => auth.currentUser ? signOutUser() : signInWithGoogle());
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Connect Google auth buttons directly to Firebase sign-in and sign-out
- Update auth UI renderer to only adjust labels, leaving click handlers intact

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a06e5fedbc8330ace1a4bc61586b27