### PR TITLE
Cap quiz session count with queued indicator

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -20,6 +20,7 @@ const SCORE_WINDOW = 10;
 const LS_TEST_SESSION = 'tm_session';
 const SCORE_COOLDOWN_MS = 60 * 60 * 1000; // 60 minutes
 const STRUGGLE_CAP = 10;
+const SESSION_MAX = 15;
 
 function deckKeyFromState() {
   // Prefer the JSON filename stem already used by the fetch; fall back to STATE.activeDeckId.
@@ -682,6 +683,8 @@ async function renderPhraseDashboard(){
   });
   const strugglingCount = enriched.filter(x=>x.status==='Struggling').length;
   const reviewDue       = await fcGetTestQueueCount();
+  const quizToday       = Math.min(reviewDue, SESSION_MAX);
+  const quizQueued      = Math.max(reviewDue - SESSION_MAX, 0);
 
   // new phrases allowance
   const daily = loadNewDaily(deckId);
@@ -700,7 +703,7 @@ async function renderPhraseDashboard(){
     bannerText = 'New phrases paused';
   }
 
-  const quizCount = reviewDue;
+  const quizCount = quizToday;
   const learned   = Object.keys(seen).length;
   const deckPct   = rows.length ? Math.round((learned/rows.length)*100) : 0;
 
@@ -736,7 +739,7 @@ async function renderPhraseDashboard(){
               <div class="badge" id="b-quiz">0</div>
             </div>
             <div class="label">Quiz</div>
-            <div class="sub">Multiple choice / type</div>
+            <div class="sub">Multiple choice / type <span class="queued-pill hidden" id="quizQueued"></span></div>
           </a>
 
           <a class="skill" id="sk-all">
@@ -775,6 +778,11 @@ async function renderPhraseDashboard(){
   wrap.querySelector('#b-new').textContent    = newToday;
   wrap.querySelector('#b-review').textContent = reviewDue;
   wrap.querySelector('#b-quiz').textContent   = quizCount;
+  if (quizQueued > 0) {
+    const qp = wrap.querySelector('#quizQueued');
+    qp.textContent = `+${quizQueued} queued`;
+    qp.classList.remove('hidden');
+  }
 
   // daily ring
   const pct = newTodayAllowed ? Math.round((used/newTodayAllowed)*100) : 0;

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -1380,6 +1380,7 @@ const SCORE_WINDOW = 10;
 const LS_TEST_SESSION = 'tm_session';
 const SCORE_COOLDOWN_MS = 60 * 60 * 1000; // 60 minutes
 const STRUGGLE_CAP = 10;
+const SESSION_MAX = 15;
 
 function deckKeyFromState() {
   // Prefer the JSON filename stem already used by the fetch; fall back to STATE.activeDeckId.
@@ -2026,6 +2027,8 @@ async function renderPhraseDashboard(){
   });
   const strugglingCount = enriched.filter(x=>x.status==='Struggling').length;
   const reviewDue       = await fcGetTestQueueCount();
+  const quizToday       = Math.min(reviewDue, SESSION_MAX);
+  const quizQueued      = Math.max(reviewDue - SESSION_MAX, 0);
 
   // new phrases allowance
   const daily = loadNewDaily(deckId);
@@ -2044,7 +2047,7 @@ async function renderPhraseDashboard(){
     bannerText = 'New phrases paused';
   }
 
-  const quizCount = reviewDue;
+  const quizCount = quizToday;
   const learned   = Object.keys(seen).length;
   const deckPct   = rows.length ? Math.round((learned/rows.length)*100) : 0;
 
@@ -2085,7 +2088,7 @@ async function renderPhraseDashboard(){
               <div class="badge" id="b-quiz">0</div>
             </div>
             <div class="label">Quiz</div>
-            <div class="sub">Multiple choice / type</div>
+            <div class="sub">Multiple choice / type <span class="queued-pill hidden" id="quizQueued"></span></div>
           </a>
 
           <a class="skill" id="sk-all">
@@ -2123,6 +2126,11 @@ async function renderPhraseDashboard(){
   wrap.querySelector('#b-new').textContent    = newToday;
   wrap.querySelector('#b-review').textContent = reviewDue;
   wrap.querySelector('#b-quiz').textContent   = quizCount;
+  if (quizQueued > 0) {
+    const qp = wrap.querySelector('#quizQueued');
+    qp.textContent = `+${quizQueued} queued`;
+    qp.classList.remove('hidden');
+  }
   wrap.querySelector('#day-count').textContent = getDayNumber();
 
   // daily ring

--- a/styles/main.css
+++ b/styles/main.css
@@ -310,6 +310,15 @@ body { background: #ffffff !important; color: #0f1117 !important; }
 }
 .skill .label{ margin-top:10px; font-weight:800; }
 .skill .sub{ font-size:12px; color:var(--muted); }
+.skill .sub .queued-pill{
+  margin-left:4px;
+  padding:0 6px;
+  border-radius:9999px;
+  background:var(--border);
+  color:var(--muted);
+  font-size:10px;
+  font-weight:700;
+}
 
 .skill:hover .bubble{ border-color: var(--welsh-red); transform: translateY(-1px); transition: transform .12s ease; }
 


### PR DESCRIPTION
## Summary
- Cap quiz badge at session max and compute queued items
- Display queued count as pill under quiz label when exceeding cap
- Add styling for queued-pill and update bundled script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a18a49055c83309aea5b3567ff6e20