### PR TITLE
feat: show daily new allowance

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -107,12 +107,8 @@ async function updateStatusPills(){
   const newEl=document.getElementById('newDisplay');
   if(newEl){
     let txt=`${newToday} new`;
-    if(allowed < SETTINGS.newPerDay){
-      if(allowed===0 && strugglingCount >= STRUGGLE_CAP){
-        txt += ` — Paused — too many struggling (${strugglingCount}/${STRUGGLE_CAP})`;
-      }else{
-        txt += ` — Reduced new (${allowed}/${SETTINGS.newPerDay})`;
-      }
+    if(allowed < SETTINGS.newPerDay && allowed===0 && strugglingCount >= STRUGGLE_CAP){
+      txt += ` — Paused — too many struggling (${strugglingCount}/${STRUGGLE_CAP})`;
     }
     newEl.textContent=txt;
   }

--- a/styles/main.css
+++ b/styles/main.css
@@ -556,3 +556,7 @@ body { background: #ffffff !important; color: #0f1117 !important; }
   background: var(--welsh-green);
   color: #fff;
 }
+.status-pill.gray {
+  background: #e0e0e0;
+  color: #333;
+}


### PR DESCRIPTION
## Summary
- Remove reduced-new message from dashboard and show pause only when struggling cap hit
- Display today's new allowance on New Phrases screen and hide when quota used
- Add gray status pill style for allowance indicator

## Testing
- `node --check js/app.js`
- `node --check js/newPhrase.js`
- `node --check js/bundle.js`


------
https://chatgpt.com/codex/tasks/task_e_68a18c2a8af0833083538041a17010f4