### PR TITLE
feat: unify learning card styles and expand flashcards

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -460,8 +460,13 @@ function getDailyNewAllowance(unseenCount, newTodayUsed, strugglingCount){
 function renderTestShell(){
   const wrap=document.createElement('div');
   wrap.innerHTML = `
-    <h1 class="h1">Test Mode</h1>
-    <section class="card card--center"><div id="test-container"></div></section>`;
+    <section class="learn-card is-quiz">
+      <div class="learn-card-header">
+        <div class="lc-left"><img src="media/icons/Quiz.png" alt="" class="lc-icon"><h2 class="lc-title">Quiz</h2></div>
+        <div class="lc-right"></div>
+      </div>
+      <div class="learn-card-content card--center"><div id="test-container"></div></div>
+    </section>`;
   return wrap;
 }
 function renderSettings(){

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -206,10 +206,14 @@ function fireProgressEvent(payload){
 
   async function renderNewPhrase(){
     const host=document.createElement('div');
-    host.innerHTML=`<h1 class="h1">New Words</h1>
-      <div class="muted" id="np-day-wrap">Day <span id="np-day">1</span></div>
-      <div class="status-pill gray" id="np-allowance" style="display:none; margin-top:4px;"></div>
-      <section class="card card--center"><div id="np-root" class="flashcard"></div></section>`;
+    host.innerHTML=`<div class="muted" id="np-day-wrap">Day <span id="np-day">1</span></div>
+      <section class="learn-card is-phrases">
+        <div class="learn-card-header">
+          <div class="lc-left"><img src="media/icons/New%20Phrases.png" alt="" class="lc-icon"><h2 class="lc-title">New Phrases</h2></div>
+          <div class="lc-right"><span class="pill default" id="np-allowance" style="display:none;"></span></div>
+        </div>
+        <div class="learn-card-content card--center"><div id="np-root" class="flashcard"></div></div>
+      </section>`;
     viewEl=host.querySelector('#np-root');
 
     const deckId = dk;
@@ -597,8 +601,7 @@ async function renderReview(query) {
 
   if (!cards.length) {
     const err = document.createElement('div');
-    err.innerHTML = `<h1 class="h1">Review <span class="muted">(${activeDeck.name})</span></h1>` +
-      `<section class="card card--center">No introduced cards. Use New Phrases first.</section>`;
+    err.innerHTML = `<section class="learn-card is-flashcards"><div class="learn-card-header"><div class="lc-left"><img src="media/icons/Flashcards.png" alt="" class="lc-icon"><h2 class="lc-title">Flashcards</h2></div></div><div class="learn-card-content card--center">No introduced cards. Use New Phrases first.</div></section>`;
     return err;
   }
 
@@ -614,17 +617,21 @@ async function renderReview(query) {
 
   const wrap = document.createElement('div');
   wrap.innerHTML = `
-    <h1 class="h1">Review <span class="muted">(${activeDeck.name})</span></h1>
-    <section class="card card--center">
-      <div class="flashcard" id="flashcard" data-view="${STATE.viewMode}">
-        <div class="fc-topbar">
-          <div class="fc-viewtoggle">
-            <label class="toggle">
-              <input type="checkbox" id="viewToggle" ${STATE.viewMode === 'detail' ? 'checked' : ''}>
-              <span class="tlabel"><span>Flashcard</span><span>Detailed</span></span>
-            </label>
+    <section class="learn-card is-flashcards">
+      <div class="learn-card-header">
+        <div class="lc-left"><img src="media/icons/Flashcards.png" alt="" class="lc-icon"><h2 class="lc-title">Flashcards</h2></div>
+        <div class="lc-right"></div>
+      </div>
+      <div class="learn-card-content card--center">
+        <div class="flashcard" id="flashcard" data-view="${STATE.viewMode}">
+          <div class="fc-topbar">
+            <div class="fc-viewtoggle">
+              <label class="toggle">
+                <input type="checkbox" id="viewToggle" ${STATE.viewMode === 'detail' ? 'checked' : ''}>
+                <span class="tlabel"><span>Flashcard</span><span>Detailed</span></span>
+              </label>
+            </div>
           </div>
-        </div>
 
         <div class="flashcard-image" id="fcImg"></div>
 
@@ -647,6 +654,7 @@ async function renderReview(query) {
         </div>
 
         <div class="flashcard-progress muted" id="fcProg"></div>
+        </div>
       </div>
     </section>
   `;
@@ -1857,8 +1865,13 @@ function getDailyNewAllowance(unseenCount, newTodayUsed, strugglingCount){
 function renderTestShell(){
   const wrap=document.createElement('div');
   wrap.innerHTML = `
-    <h1 class="h1">Test Mode</h1>
-    <section class="card card--center"><div id="test-container"></div></section>`;
+    <section class="learn-card is-quiz">
+      <div class="learn-card-header">
+        <div class="lc-left"><img src="media/icons/Quiz.png" alt="" class="lc-icon"><h2 class="lc-title">Quiz</h2></div>
+        <div class="lc-right"></div>
+      </div>
+      <div class="learn-card-content card--center"><div id="test-container"></div></div>
+    </section>`;
   return wrap;
 }
 function renderSettings(){

--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -318,10 +318,14 @@ function updateAllowancePill(){
 /* ---------- Render host ---------- */
 async function renderNewPhrase(){
   const host=document.createElement('div');
-  host.innerHTML=`<h1 class="h1">New Words</h1>
-    <div class="muted" id="np-day-wrap">Day <span id="np-day">1</span></div>
-    <div class="status-pill gray" id="np-allowance" style="display:none; margin-top:4px;"></div>
-    <section class="card card--center"><div id="np-root" class="flashcard"></div></section>`;
+  host.innerHTML=`<div class="muted" id="np-day-wrap">Day <span id="np-day">1</span></div>
+    <section class="learn-card is-phrases">
+      <div class="learn-card-header">
+        <div class="lc-left"><img src="media/icons/New%20Phrases.png" alt="" class="lc-icon"><h2 class="lc-title">New Phrases</h2></div>
+        <div class="lc-right"><span class="pill default" id="np-allowance" style="display:none;"></span></div>
+      </div>
+      <div class="learn-card-content card--center"><div id="np-root" class="flashcard"></div></div>
+    </section>`;
   viewEl=host.querySelector('#np-root');
   host.querySelector('#np-day').textContent=getDayNumber?.() || '—';
 

--- a/js/study.js
+++ b/js/study.js
@@ -104,8 +104,7 @@ async function renderReview(query) {
 
   if (!cards.length) {
     const err = document.createElement('div');
-    err.innerHTML = `<h1 class="h1">Review <span class="muted">(${activeDeck.name})</span></h1>` +
-      `<section class="card card--center">No introduced cards. Use New Phrases first.</section>`;
+    err.innerHTML = `<section class="learn-card is-flashcards"><div class="learn-card-header"><div class="lc-left"><img src="media/icons/Flashcards.png" alt="" class="lc-icon"><h2 class="lc-title">Flashcards</h2></div></div><div class="learn-card-content card--center">No introduced cards. Use New Phrases first.</div></section>`;
     return err;
   }
 
@@ -121,17 +120,21 @@ async function renderReview(query) {
 
   const wrap = document.createElement('div');
   wrap.innerHTML = `
-    <h1 class="h1">Review <span class="muted">(${activeDeck.name})</span></h1>
-    <section class="card card--center">
-      <div class="flashcard" id="flashcard" data-view="${STATE.viewMode}">
-        <div class="fc-topbar">
-          <div class="fc-viewtoggle">
-            <label class="toggle">
-              <input type="checkbox" id="viewToggle" ${STATE.viewMode === 'detail' ? 'checked' : ''}>
-              <span class="tlabel"><span>Flashcard</span><span>Detailed</span></span>
-            </label>
+    <section class="learn-card is-flashcards">
+      <div class="learn-card-header">
+        <div class="lc-left"><img src="media/icons/Flashcards.png" alt="" class="lc-icon"><h2 class="lc-title">Flashcards</h2></div>
+        <div class="lc-right"></div>
+      </div>
+      <div class="learn-card-content card--center">
+        <div class="flashcard" id="flashcard" data-view="${STATE.viewMode}">
+          <div class="fc-topbar">
+            <div class="fc-viewtoggle">
+              <label class="toggle">
+                <input type="checkbox" id="viewToggle" ${STATE.viewMode === 'detail' ? 'checked' : ''}>
+                <span class="tlabel"><span>Flashcard</span><span>Detailed</span></span>
+              </label>
+            </div>
           </div>
-        </div>
 
         <div class="flashcard-image" id="fcImg"></div>
 
@@ -154,6 +157,7 @@ async function renderReview(query) {
         </div>
 
         <div class="flashcard-progress muted" id="fcProg"></div>
+        </div>
       </div>
     </section>
   `;

--- a/styles/cards.css
+++ b/styles/cards.css
@@ -1,12 +1,59 @@
+/* Learning card */
+.learn-card{
+  background:#FFFFFF;
+  border:1px solid #E7ECEA;
+  border-radius:16px;
+  box-shadow:0 8px 24px rgba(16,32,21,.08);
+  padding:16px;
+  display:flex;
+  flex-direction:column;
+  position:relative;
+  overflow:hidden;
+}
+.learn-card:hover{ box-shadow:0 12px 32px rgba(16,32,21,.10); }
+@media (min-width:431px){ .learn-card{ padding:20px; } }
+@media (min-width:769px){ .learn-card{ padding:24px; border-radius:20px; } }
+@media (min-width:921px){ .learn-card{ padding:28px; border-radius:24px; } }
+
+.learn-card-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; }
+.learn-card-header .lc-left{ display:flex; align-items:center; gap:12px; }
+.learn-card-header .lc-icon{ width:24px; height:24px; }
+@media (min-width:769px){ .learn-card-header .lc-icon{ width:26px; height:26px; } }
+@media (min-width:921px){ .learn-card-header .lc-icon{ width:28px; height:28px; } }
+.learn-card-header .lc-title{ font-weight:700; font-size:18px; margin:0; }
+@media (min-width:769px){ .learn-card-header .lc-title{ font-size:20px; } }
+@media (min-width:921px){ .learn-card-header .lc-title{ font-size:22px; } }
+.learn-card-header .lc-right{ display:flex; flex-wrap:wrap; gap:8px; }
+.learn-card-header .pill{ border-radius:9999px; padding:4px 10px; font-size:12px; font-weight:700; }
+@media (min-width:769px){ .learn-card-header .pill{ font-size:13px; } }
+.pill{ display:inline-block; }
+.pill.default{ background:#E9F5ED; color:#1C8E4A; }
+.pill.queued{ background:#EEF0F7; color:#334067; }
+.pill.restricted{ background:#FDE6EA; color:#B10E24; }
+
+.learn-card-content{ margin-top:16px; }
+.learn-card-content.card--center{ display:flex; justify-content:center; }
+.learn-card input:focus, .learn-card textarea:focus{ outline:2px solid #2B7BFF; outline-offset:2px; }
+.learn-card .flashcard-actions{ border-top:1px solid #F1F4F3; padding-top:16px; }
+.learn-card .flashcard-actions .btn{ border-radius:9999px; min-height:44px; }
+
+.learn-card.is-phrases::before,
+.learn-card.is-flashcards::before,
+.learn-card.is-quiz::before{
+  content:""; position:absolute; top:0; left:0; right:0; height:3px;
+}
+.learn-card.is-phrases::before{ background:#FF8A1E; }
+.learn-card.is-flashcards::before{ background:#73D2FF; }
+.learn-card.is-quiz::before{ background:#3CA861; }
+
 /* Flashcard layout */
 .card--center { display: flex; justify-content: center; }
 .flashcard {
-  width: 100%; max-width: 420px;
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 16px; box-shadow: var(--shadow);
-  padding: 16px; display: flex; flex-direction: column; gap: 14px;
+  width: 100%;
+  display: flex; flex-direction: column; gap: 14px;
+  min-height:240px;
 }
+@media (min-width:768px){ .flashcard{ min-height:360px; } }
 
 /* Toggle */
 .fc-topbar { display: flex; justify-content: flex-end; }
@@ -64,7 +111,6 @@
 
 /* Mobile tweaks */
 @media (max-width: 430px) {
-  .flashcard { max-width: 100%; padding: 14px; }
   .term { font-size: 24px; }
   .translation { font-size: 16px; }
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -383,15 +383,62 @@ body { background: #ffffff !important; color: #0f1117 !important; }
 
 /* Filter bar for learned phrases */
 .filter-bar{ margin:12px 0; }
+/* Learning card */
+.learn-card{
+  background:#FFFFFF;
+  border:1px solid #E7ECEA;
+  border-radius:16px;
+  box-shadow:0 8px 24px rgba(16,32,21,.08);
+  padding:16px;
+  display:flex;
+  flex-direction:column;
+  position:relative;
+  overflow:hidden;
+}
+.learn-card:hover{ box-shadow:0 12px 32px rgba(16,32,21,.10); }
+@media (min-width:431px){ .learn-card{ padding:20px; } }
+@media (min-width:769px){ .learn-card{ padding:24px; border-radius:20px; } }
+@media (min-width:921px){ .learn-card{ padding:28px; border-radius:24px; } }
+
+.learn-card-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; }
+.learn-card-header .lc-left{ display:flex; align-items:center; gap:12px; }
+.learn-card-header .lc-icon{ width:24px; height:24px; }
+@media (min-width:769px){ .learn-card-header .lc-icon{ width:26px; height:26px; } }
+@media (min-width:921px){ .learn-card-header .lc-icon{ width:28px; height:28px; } }
+.learn-card-header .lc-title{ font-weight:700; font-size:18px; margin:0; }
+@media (min-width:769px){ .learn-card-header .lc-title{ font-size:20px; } }
+@media (min-width:921px){ .learn-card-header .lc-title{ font-size:22px; } }
+.learn-card-header .lc-right{ display:flex; flex-wrap:wrap; gap:8px; }
+.learn-card-header .pill{ border-radius:9999px; padding:4px 10px; font-size:12px; font-weight:700; }
+@media (min-width:769px){ .learn-card-header .pill{ font-size:13px; } }
+.pill{ display:inline-block; }
+.pill.default{ background:#E9F5ED; color:#1C8E4A; }
+.pill.queued{ background:#EEF0F7; color:#334067; }
+.pill.restricted{ background:#FDE6EA; color:#B10E24; }
+
+.learn-card-content{ margin-top:16px; }
+.learn-card-content.card--center{ display:flex; justify-content:center; }
+.learn-card input:focus, .learn-card textarea:focus{ outline:2px solid #2B7BFF; outline-offset:2px; }
+.learn-card .flashcard-actions{ border-top:1px solid #F1F4F3; padding-top:16px; }
+.learn-card .flashcard-actions .btn{ border-radius:9999px; min-height:44px; }
+
+.learn-card.is-phrases::before,
+.learn-card.is-flashcards::before,
+.learn-card.is-quiz::before{
+  content:""; position:absolute; top:0; left:0; right:0; height:3px;
+}
+.learn-card.is-phrases::before{ background:#FF8A1E; }
+.learn-card.is-flashcards::before{ background:#73D2FF; }
+.learn-card.is-quiz::before{ background:#3CA861; }
+
 /* Flashcard layout */
 .card--center { display: flex; justify-content: center; }
 .flashcard {
-  width: 100%; max-width: 420px;
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 16px; box-shadow: var(--shadow);
-  padding: 16px; display: flex; flex-direction: column; gap: 14px;
+  width: 100%;
+  display: flex; flex-direction: column; gap: 14px;
+  min-height:240px;
 }
+@media (min-width:768px){ .flashcard{ min-height:360px; } }
 
 /* Toggle */
 .fc-topbar { display: flex; justify-content: flex-end; }
@@ -449,7 +496,6 @@ body { background: #ffffff !important; color: #0f1117 !important; }
 
 /* Mobile tweaks */
 @media (max-width: 430px) {
-  .flashcard { max-width: 100%; padding: 14px; }
   .term { font-size: 24px; }
   .translation { font-size: 16px; }
 }


### PR DESCRIPTION
## Summary
- Introduce reusable `.learn-card` with responsive padding, hover shadow, and per-module accent bars
- Apply new card structure to New Phrases, Flashcards, and Quiz screens
- Drop 420px width cap on flashcard stage and add flexible height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ba9e8724833094868cdd97886cd3