### PR TITLE
Refine card UI consistency

### DIFF
--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -322,7 +322,7 @@ async function renderNewPhrase(){
     <section class="learn-card is-phrases">
       <div class="learn-card-header">
         <div class="lc-left"><img src="media/icons/New%20Phrases.png" alt="" class="lc-icon"><h2 class="lc-title">New Phrases</h2></div>
-        <div class="lc-right"><span class="pill default" id="np-allowance" style="display:none;"></span></div>
+        <div class="lc-right"><span class="pill default" id="np-allowance" hidden></span></div>
       </div>
       <div class="learn-card-content card--center"><div id="np-root" class="flashcard"></div></div>
     </section>`;

--- a/js/study.js
+++ b/js/study.js
@@ -140,7 +140,7 @@ async function renderReview(query) {
 
         <div class="fc-phrase">
           <div class="term" id="fcTerm" title="Tap to flip in Flashcard mode"></div>
-          <button class="btn audio-btn" id="audioBtn" title="Play (alternates fast/slow)">🔊 Play</button>
+          <button class="btn audio-btn play-btn" id="audioBtn" title="Play (alternates fast/slow)">🔊 Play</button>
           <div class="phonetic" id="fcPhon"></div>
         </div>
 

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -331,7 +331,7 @@
 
     container.innerHTML = `
       <div class="flashcard">
-        <div class="translation">${escapeHTML(c.back)}</div>
+        <div class="translation tm-question">${escapeHTML(c.back)}</div>
         <div class="tm-inputblock">
           <label for="tm-answer" class="tm-label">Type the Welsh</label>
           <input id="tm-answer" class="tm-field" type="text" placeholder="Type the Welsh…" autocomplete="off" autocapitalize="off" spellcheck="false">
@@ -443,7 +443,7 @@
     function blindStep(attempt){
       container.innerHTML = `
         <div class="flashcard">
-          <div class="translation">${escapeHTML(card.back)}</div>
+          <div class="translation tm-question">${escapeHTML(card.back)}</div>
           <div class="tm-inputblock" style="margin-top:8px;">
             <label class="tm-label">Type the Welsh</label>
             <input id="tm-drill" class="tm-field" type="text" placeholder="Type the Welsh…" autocomplete="off" autocapitalize="off" spellcheck="false">

--- a/styles/main.css
+++ b/styles/main.css
@@ -389,18 +389,18 @@ body { background: #ffffff !important; color: #0f1117 !important; }
   border:1px solid #E7ECEA;
   border-radius:16px;
   box-shadow:0 8px 24px rgba(16,32,21,.08);
-  padding:16px;
+  padding:16px 0;
   display:flex;
   flex-direction:column;
   position:relative;
   overflow:hidden;
 }
 .learn-card:hover{ box-shadow:0 12px 32px rgba(16,32,21,.10); }
-@media (min-width:431px){ .learn-card{ padding:20px; } }
-@media (min-width:769px){ .learn-card{ padding:24px; border-radius:20px; } }
-@media (min-width:921px){ .learn-card{ padding:28px; border-radius:24px; } }
+@media (min-width:431px){ .learn-card{ padding:20px 0; } }
+@media (min-width:769px){ .learn-card{ padding:24px 0; border-radius:20px; } }
+@media (min-width:921px){ .learn-card{ padding:28px 0; border-radius:24px; } }
 
-.learn-card-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; }
+.learn-card-header{ display:flex; align-items:center; justify-content:space-between; gap:12px; padding:0 16px; }
 .learn-card-header .lc-left{ display:flex; align-items:center; gap:12px; }
 .learn-card-header .lc-icon{ width:24px; height:24px; }
 @media (min-width:769px){ .learn-card-header .lc-icon{ width:26px; height:26px; } }
@@ -408,28 +408,29 @@ body { background: #ffffff !important; color: #0f1117 !important; }
 .learn-card-header .lc-title{ font-weight:700; font-size:18px; margin:0; }
 @media (min-width:769px){ .learn-card-header .lc-title{ font-size:20px; } }
 @media (min-width:921px){ .learn-card-header .lc-title{ font-size:22px; } }
-.learn-card-header .lc-right{ display:flex; flex-wrap:wrap; gap:8px; }
-.learn-card-header .pill{ border-radius:9999px; padding:4px 10px; font-size:12px; font-weight:700; }
+.learn-card-header .lc-right{ display:flex; flex-wrap:wrap; gap:8px; align-self:flex-start; }
+.learn-card-header .pill{ border-radius:9999px; padding:4px 8px; font-size:12px; font-weight:700; }
 @media (min-width:769px){ .learn-card-header .pill{ font-size:13px; } }
 .pill{ display:inline-block; }
 .pill.default{ background:#E9F5ED; color:#1C8E4A; }
 .pill.queued{ background:#EEF0F7; color:#334067; }
 .pill.restricted{ background:#FDE6EA; color:#B10E24; }
 
-.learn-card-content{ margin-top:16px; }
+.learn-card-content{ margin-top:16px; padding:0 16px; }
 .learn-card-content.card--center{ display:flex; justify-content:center; }
 .learn-card input:focus, .learn-card textarea:focus{ outline:2px solid #2B7BFF; outline-offset:2px; }
 .learn-card .flashcard-actions{ border-top:1px solid #F1F4F3; padding-top:16px; }
-.learn-card .flashcard-actions .btn{ border-radius:9999px; min-height:44px; }
+.learn-card .flashcard-actions .btn{ border-radius:9999px; min-height:44px; padding:12px 24px; background:var(--panel); transition:background .18s ease; }
+.learn-card .flashcard-actions .btn:hover{ background:var(--panel-2); }
 
 .learn-card.is-phrases::before,
 .learn-card.is-flashcards::before,
 .learn-card.is-quiz::before{
-  content:""; position:absolute; top:0; left:0; right:0; height:3px;
+  content:""; position:absolute; top:0; left:16px; right:16px; height:2px; border-radius:2px;
 }
 .learn-card.is-phrases::before{ background:#FF8A1E; }
-.learn-card.is-flashcards::before{ background:#73D2FF; }
-.learn-card.is-quiz::before{ background:#3CA861; }
+.learn-card.is-flashcards::before{ background:#B3E5FC; }
+.learn-card.is-quiz::before{ background:#C8E6C9; }
 
 /* Flashcard layout */
 .card--center { display: flex; justify-content: center; }
@@ -460,10 +461,12 @@ body { background: #ffffff !important; color: #0f1117 !important; }
 .fc-phrase { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 10px; }
 .term { text-align: center; font-size: 28px; font-weight: 800; color: var(--text); }
 .audio-btn { min-width: 88px; }
+.play-btn { margin-top:12px; }
 .phonetic { grid-column: 1 / -1; text-align: center; font-size: 13px; color: var(--muted); }
 
 /* Translation */
 .translation { text-align: center; font-size: 18px; font-weight: 700; color: var(--text); }
+.tm-question{ font-weight:600; }
 .hidden { display: none !important; }
 
 /* Breakdown chips */


### PR DESCRIPTION
## Summary
- Restyle card headers and pills with unified padding and layout
- Soften accent bars and standardize nav buttons and question styling
- Add breathing room for flashcard play button and emphasize quiz prompts

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bdfce52c8330a49a24f257619d46