### PR TITLE
Unify bucket model and global new phrase cap

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@
   </div>
 
   <script src="js/errorBanner.js" defer></script>
+  <script src="js/utils.js" defer></script>
   <script src="js/bundle.js" defer></script>
   <script type="module" src="js/firebase.js"></script>
 </body>

--- a/js/study.js
+++ b/js/study.js
@@ -11,7 +11,6 @@ function deckKeyFromState() {
 
 const dk          = deckKeyFromState();
 const progressKey = 'progress_' + dk;          // read/write here
-const dailyKey    = 'np_daily_' + dk;          // read in Test/Study; read/write in New Phrases
 const attemptsKey = 'tm_attempts_v1';          // global attempts bucket (unchanged)
 
 (function migrateProgressIfNeeded(){

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,97 @@
+(function(global){
+  const BUCKETS = {
+    NEW: 'NEW',
+    STRUGGLING: 'STRUGGLING',
+    NEEDS_WORK: 'NEEDS_WORK',
+    CONFIDENT: 'CONFIDENT',
+    MASTERED: 'MASTERED'
+  };
+
+  const BUCKET_LABELS = {
+    NEW: 'New',
+    STRUGGLING: 'Struggling',
+    NEEDS_WORK: 'Needs work',
+    CONFIDENT: 'Confident',
+    MASTERED: 'Mastered'
+  };
+
+  function getLocalISODate(){
+    const d = new Date();
+    d.setHours(0,0,0,0);
+    return d.toISOString().slice(0,10);
+  }
+
+  function getBucketFromAccuracy(opts){
+    const {
+      accPct = 0,
+      attempts = 0,
+      lastFails = 0,
+      lastFailAt = 0,
+      isSeen = false,
+      isAttempted = false
+    } = opts || {};
+
+    if(isSeen && attempts === 0) return BUCKETS.NEW;
+    if(attempts > 0 && (accPct < 50 || lastFails >= 2 || (lastFailAt && (Date.now() - lastFailAt) < 48*3600*1000))) return BUCKETS.STRUGGLING;
+    if(accPct < 80) return BUCKETS.NEEDS_WORK;
+    if(accPct < 90) return BUCKETS.CONFIDENT;
+    return BUCKETS.MASTERED;
+  }
+
+  const ALLOW_PREFIX = 'siarad:newAllowance:';
+  let capLogged = false;
+  function readAllowance(){
+    const today = getLocalISODate();
+    const key = ALLOW_PREFIX + today;
+    let data;
+    try{ data = JSON.parse(localStorage.getItem(key) || '{}'); }catch{}
+    const base = (global.SETTINGS && global.SETTINGS.newPerDay) || 5;
+    if(!data || data.lastDate !== today || typeof data.remaining !== 'number'){
+      data = { remaining: base, lastDate: today };
+      localStorage.setItem(key, JSON.stringify(data));
+    }
+    if(!capLogged){
+      console.info(`New cap today: ${data.remaining}/${base}`);
+      capLogged = true;
+    }
+    data.key = key;
+    return data;
+  }
+  function saveAllowance(data){
+    localStorage.setItem(data.key, JSON.stringify({ remaining: data.remaining, lastDate: data.lastDate }));
+  }
+
+  function getDailyNewAllowance(unseenCount=0, strugglingCount=0){
+    const state = readAllowance();
+    const base = (global.SETTINGS && global.SETTINGS.newPerDay) || 5;
+    const cap = (global.STRUGGLE_CAP || 10);
+    const factor = Math.max(0, Math.min(1, (cap - strugglingCount) / cap));
+    const baseAllowed = Math.floor(base * factor);
+    const allowed = Math.min(state.remaining, baseAllowed, unseenCount, base);
+    return { allowed, remaining: state.remaining, baseAllowed };
+  }
+
+  function consumeNewAllowance(){
+    const state = readAllowance();
+    if(state.remaining > 0){
+      state.remaining -= 1;
+      saveAllowance(state);
+      console.info(`New item introduced; remaining now ${state.remaining}`);
+    }
+  }
+
+  function peekAllowance(){
+    const state = readAllowance();
+    return { remaining: state.remaining };
+  }
+
+  global.FC_UTILS = {
+    BUCKETS,
+    BUCKET_LABELS,
+    getBucketFromAccuracy,
+    getLocalISODate,
+    getDailyNewAllowance,
+    consumeNewAllowance,
+    peekAllowance
+  };
+})(window);


### PR DESCRIPTION
## Summary
- introduce shared utils with canonical confidence buckets and global new-item allowance
- switch app dashboards and flows to `getBucketFromAccuracy` and new allowance logic
- track new phrases globally and prevent over-cap introductions across decks

## Testing
- `node --check js/utils.js`
- `node --check js/app.js`
- `node --check js/newPhrase.js`
- `node --check js/testMode.js`
- `node --check js/study.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d77fcf1c8330a818d5e8b3f10ff7