### PR TITLE
Display deck status donut chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
 
   <script src="js/errorBanner.js" defer></script>
   <script src="js/utils.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
   <script src="js/bundle.js" defer></script>
   <script type="module" src="js/firebase.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Load Chart.js so deck status card can render a doughnut chart showing phrase buckets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a207a4a6388330bca42cee48bc87ef