### PR TITLE
Revise card progress buckets based on accuracy

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -159,10 +159,7 @@ async function updateStatusPills(){
     const bucket = getBucketFromAccuracy({
       accPct: acc,
       attempts: meta.attempts,
-      lastFails: meta.lastFails,
-      lastFailAt: meta.lastFailAt,
-      isSeen: !!seen[r.id],
-      isAttempted: meta.attempts > 0
+      introducedAt: seen[r.id] && seen[r.id].firstSeen
     });
     return {bucket};
   });
@@ -469,10 +466,7 @@ async function getPhraseBuckets(deckId){
     const bucket = getBucketFromAccuracy({
       accPct: acc,
       attempts: meta.attempts,
-      lastFails: meta.lastFails,
-      lastFailAt: meta.lastFailAt,
-      isSeen: !!seen[r.id],
-      isAttempted: meta.attempts > 0
+      introducedAt: seen[r.id] && seen[r.id].firstSeen
     });
     if(bucket === BUCKETS.STRUGGLING) counts.struggling++;
     else if(bucket === BUCKETS.MASTERED) counts.mastered++;
@@ -542,10 +536,7 @@ async function renderLearned(){
     const bucket = getBucketFromAccuracy({
       accPct: acc,
       attempts: meta.attempts,
-      lastFails: meta.lastFails,
-      lastFailAt: meta.lastFailAt,
-      isSeen: !!seen[r.id],
-      isAttempted: meta.attempts > 0
+      introducedAt: seen[r.id] && seen[r.id].firstSeen
     });
     const status = BUCKET_LABELS[bucket];
     const tries = meta.attempts;
@@ -804,10 +795,7 @@ async function renderPhraseDashboard(){
     const bucket = getBucketFromAccuracy({
       accPct: acc,
       attempts: meta.attempts,
-      lastFails: meta.lastFails,
-      lastFailAt: meta.lastFailAt,
-      isSeen: !!seen[r.id],
-      isAttempted: meta.attempts > 0
+      introducedAt: seen[r.id] && seen[r.id].firstSeen
     });
     return { ...r, acc, bucket };
   });

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -1877,7 +1877,7 @@ async function getPhraseBuckets(deckId){
     if(!seen[r.id] && arr.length===0){counts.untested++;return;}
     if(arr.length===0){counts.new++;counts.total++;return;}
     const acc = lastNAccuracy(r.id, SCORE_WINDOW, attempts);
-    const bucket = FC_UTILS.getBucketFromAccuracy({accPct:acc,attempts:arr.length,lastFails,lastFailAt,isSeen:!!seen[r.id],isAttempted:arr.length>0});
+    const bucket = FC_UTILS.getBucketFromAccuracy({accPct:acc,attempts:arr.length,introducedAt:seen[r.id]?seen[r.id].firstSeen:undefined});
     if(bucket===FC_UTILS.BUCKETS.STRUGGLING) counts.struggling++;
     else if(bucket===FC_UTILS.BUCKETS.MASTERED) counts.mastered++;
     else counts.review++;
@@ -1972,10 +1972,7 @@ async function renderLearned(){
     const bucket = FC_UTILS.getBucketFromAccuracy({
       accPct: acc,
       attempts: arr.length,
-      lastFails,
-      lastFailAt,
-      isSeen: !!seen[r.id],
-      isAttempted: arr.length > 0
+      introducedAt: seen[r.id]?seen[r.id].firstSeen:undefined
     });
     const status = FC_UTILS.BUCKET_LABELS[bucket];
     const tries = arr.length;

--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -261,10 +261,7 @@ function computeAllMastered(deckId, prog){
     const bucket = getBucketFromAccuracy({
       accPct: acc,
       attempts: meta.attempts,
-      lastFails: meta.lastFails,
-      lastFailAt: meta.lastFailAt,
-      isSeen: true,
-      isAttempted: meta.attempts > 0
+      introducedAt: prog.seen[id] && prog.seen[id].firstSeen
     });
     return bucket === BUCKETS.MASTERED;
   });
@@ -408,10 +405,7 @@ async function renderNewPhrase(){
       const bucket = getBucketFromAccuracy({
         accPct: acc,
         attempts: meta.attempts,
-        lastFails: meta.lastFails,
-        lastFailAt: meta.lastFailAt,
-        isSeen: seenIds.has(r.id),
-        isAttempted: meta.attempts > 0
+        introducedAt: prog.seen[r.id] && prog.seen[r.id].firstSeen
       });
       return {bucket};
     });

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -233,10 +233,7 @@
       const bucket = FC_UTILS.getBucketFromAccuracy({
         accPct: acc,
         attempts: meta.attempts,
-        lastFails: meta.lastFails,
-        lastFailAt: meta.lastFailAt,
-        isSeen: !!seenMap[c.id],
-        isAttempted: meta.attempts > 0
+        introducedAt: seenMap[c.id] && seenMap[c.id].firstSeen
       });
       c.conf = acc;
       c.isStruggling = bucket === FC_UTILS.BUCKETS.STRUGGLING;

--- a/js/utils.js
+++ b/js/utils.js
@@ -2,7 +2,7 @@
   const BUCKETS = {
     NEW: 'NEW',
     STRUGGLING: 'STRUGGLING',
-    NEEDS_WORK: 'NEEDS_WORK',
+    NEEDS_REVIEW: 'NEEDS_REVIEW',
     CONFIDENT: 'CONFIDENT',
     MASTERED: 'MASTERED'
   };
@@ -10,7 +10,7 @@
   const BUCKET_LABELS = {
     NEW: 'New',
     STRUGGLING: 'Struggling',
-    NEEDS_WORK: 'Needs work',
+    NEEDS_REVIEW: 'Needs review',
     CONFIDENT: 'Confident',
     MASTERED: 'Mastered'
   };
@@ -23,17 +23,15 @@
 
   function getBucketFromAccuracy(opts){
     const {
-      accPct = 0,
+      introducedAt,
       attempts = 0,
-      lastFails = 0,
-      lastFailAt = 0,
-      isSeen = false,
-      isAttempted = false
+      accPct = 0
     } = opts || {};
 
-    if(isSeen && attempts === 0) return BUCKETS.NEW;
-    if(attempts > 0 && (accPct < 50 || lastFails >= 2 || (lastFailAt && (Date.now() - lastFailAt) < 48*3600*1000))) return BUCKETS.STRUGGLING;
-    if(accPct < 80) return BUCKETS.NEEDS_WORK;
+    if(!introducedAt) return null;
+    if(attempts === 0) return BUCKETS.NEW;
+    if(accPct < 50) return BUCKETS.STRUGGLING;
+    if(accPct < 80) return BUCKETS.NEEDS_REVIEW;
     if(accPct < 90) return BUCKETS.CONFIDENT;
     return BUCKETS.MASTERED;
   }


### PR DESCRIPTION
## Summary
- Introduce `NEEDS_REVIEW` bucket with updated labeling and thresholds
- Determine card buckets via `introducedAt`, attempt count, and accuracy
- Adjust progress calculations to use new bucketing API

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a211512c188330a6897358da371eb0