### PR TITLE
Persist first introduction timestamp for phrases

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -123,7 +123,8 @@ function backfillIntroducedAt(){
     if(!arr.length) return;
     const entry = seen[id] || {};
     if(entry.introducedAt) return;
-    entry.introducedAt = arr[0]?.ts || Date.now();
+    const ts = arr[0]?.ts;
+    entry.introducedAt = ts ? new Date(ts).toISOString() : new Date().toISOString();
     if(!entry.firstSeen){
       const d = new Date(entry.introducedAt);
       entry.firstSeen = d.toISOString().slice(0,10);

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -47,7 +47,8 @@ function backfillIntroducedAt(){
     if(!arr.length) return;
     const entry = seen[id] || {};
     if(entry.introducedAt) return;
-    entry.introducedAt = (arr[0] && arr[0].ts) || Date.now();
+    const t = arr[0] && arr[0].ts;
+    entry.introducedAt = t ? new Date(t).toISOString() : new Date().toISOString();
     if(!entry.firstSeen){
       const d=new Date(entry.introducedAt);
       entry.firstSeen=d.toISOString().slice(0,10);
@@ -137,7 +138,7 @@ function fireProgressEvent(payload){
     const entry = prog.seen[cardId] || { firstSeen: today, seenCount: 0 };
     entry.seenCount += 1;
     entry.lastSeen = today;
-    if(!entry.introducedAt) entry.introducedAt = Date.now();
+    if(!entry.introducedAt) entry.introducedAt = new Date().toISOString();
     prog.seen[cardId] = entry;
     localStorage.setItem(progressKey, JSON.stringify(prog));
     if(!wasSeen){ FC_UTILS.consumeNewAllowance(); }

--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -204,7 +204,7 @@ function markSeenNow(cardId){
   const entry = prog.seen[cardId] || { firstSeen: today, seenCount: 0 };
   entry.seenCount += 1;
   entry.lastSeen = today;
-  if(!entry.introducedAt) entry.introducedAt = Date.now();
+  if(!entry.introducedAt) entry.introducedAt = new Date().toISOString();
   prog.seen[cardId] = entry;
   localStorage.setItem(progressKey, JSON.stringify(prog));
   if(!wasSeen){ FC_UTILS.consumeNewAllowance(); }


### PR DESCRIPTION
## Summary
- Store `introducedAt` ISO timestamp when a phrase is first shown
- Backfill `introducedAt` for existing attempts using first attempt time or current time
- Update bundled script to carry new timestamp logic

## Testing
- `node --check js/newPhrase.js`
- `node --check js/app.js`
- `node --check js/bundle.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a22b81317c8330beadb93456efccca