### PR TITLE
Log review outcomes for quiz attempts

### DIFF
--- a/js/bundle.js
+++ b/js/bundle.js
@@ -1202,6 +1202,7 @@ function fireProgressEvent(payload){
     const pass = !skip && equalsLoose(val, c.front);
     if (pass) tickDay();
     logAttempt(c.id, pass, { forceNoScore: practiceMode });
+    logReview(c, pass ? 'pass' : 'fail');
     fireProgressEvent({ type:'attempt', id: c.id, pass });
     if (pass) {
       correct++;
@@ -1232,6 +1233,7 @@ function fireProgressEvent(payload){
         const val = inp.value || '';
         const ok = equalsLoose(val, card.front);
         logAttempt(card.id, ok, { forceNoScore: true });
+        logReview(card, ok ? 'pass' : 'fail');
         fireProgressEvent({ type:'attempt', id: card.id, pass: ok });
         if (ok) {
           if (step === 1) copyStep(2);
@@ -1263,6 +1265,7 @@ function fireProgressEvent(payload){
         const ok = equalsLoose(val, card.front);
         if (ok) tickDay();
         const counted = logAttempt(card.id, ok, { forceNoScore: practiceMode });
+        logReview(card, ok ? 'pass' : 'fail');
         fireProgressEvent({ type:'attempt', id: card.id, pass: ok });
         if (ok) {
           showResult(true, val, { scoreCounted: counted });

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -404,6 +404,7 @@
       behaviour: behaviour.kind,
       forceNoScore: practiceMode
     });
+    logReview(c, pass ? 'pass' : 'fail');
 
     fireProgressEvent({ type:'attempt', id:c.id, pass });
 
@@ -446,6 +447,7 @@
         const val = inp.value || '';
         const ok = equalsLoose(val, card.front);
         logAttempt(card.id, ok, { behaviour: localTracker.classify().kind, forceNoScore: true });
+        logReview(card, ok ? 'pass' : 'fail');
         fireProgressEvent({ type:'attempt', id: card.id, pass: ok });
         if (ok){
           if (step===1) copyStep(2);
@@ -479,6 +481,7 @@
         const val = inp.value || '';
         const ok = equalsLoose(val, card.front);
         const counted = logAttempt(card.id, ok, { behaviour: localTracker.classify().kind, forceNoScore: practiceMode });
+        logReview(card, ok ? 'pass' : 'fail');
         fireProgressEvent({ type:'attempt', id: card.id, pass: ok });
         if (ok){
           if (counted && !practiceMode) tickDay && tickDay();

--- a/js/utils.js
+++ b/js/utils.js
@@ -80,6 +80,33 @@
     return { remaining: state.remaining };
   }
 
+  function deckKeyFromState(){
+    const map = {
+      'Welsh – A1 Phrases': 'welsh_phrases_A1',
+      'Welsh - A1 Phrases': 'welsh_phrases_A1',
+      'welsh_a1': 'welsh_phrases_A1'
+    };
+    const id = (global.STATE && global.STATE.activeDeckId) || '';
+    return map[id] || id || 'welsh_phrases_A1';
+  }
+
+  function logReview(phrase, result){
+    const id = typeof phrase === 'string' ? phrase : phrase && phrase.id;
+    if(!id) return;
+    const progressKey = 'progress_' + deckKeyFromState();
+    let prog;
+    try{ prog = JSON.parse(localStorage.getItem(progressKey) || '{"seen":{}}'); }
+    catch{ prog = { seen:{} }; }
+    const seen = prog.seen || {};
+    const entry = seen[id] || {};
+    const reviews = entry.reviews || [];
+    reviews.push({ date: new Date().toISOString(), result });
+    entry.reviews = reviews;
+    seen[id] = entry;
+    prog.seen = seen;
+    localStorage.setItem(progressKey, JSON.stringify(prog));
+  }
+
   global.FC_UTILS = {
     BUCKETS,
     BUCKET_LABELS,
@@ -89,4 +116,6 @@
     consumeNewAllowance,
     peekAllowance
   };
+
+  global.logReview = logReview;
 })(window);


### PR DESCRIPTION
## Summary
- track per-phrase review history via `logReview`
- record quiz and drill outcomes as review entries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a22fbb952c8330a6750d9ab16309ee