### PR TITLE
Add review interval field for phrases

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -319,8 +319,18 @@ function todayKey() {
 function loadProgress(deckId){
   const dk = deckId || deckKeyFromState();
   const progressKey = LS_PROGRESS_PREFIX + dk;
-  try{ return JSON.parse(localStorage.getItem(progressKey) || '{}'); }
-  catch { return {}; }
+  let obj;
+  try { obj = JSON.parse(localStorage.getItem(progressKey) || '{}'); }
+  catch { obj = {}; }
+  const seen = obj.seen || {};
+  Object.keys(seen).forEach(id => {
+    const entry = seen[id] || {};
+    const n = typeof entry.interval === 'number' ? entry.interval : 1;
+    entry.interval = FC_UTILS.clampInterval(n);
+    seen[id] = entry;
+  });
+  obj.seen = seen;
+  return obj;
 }
 function saveProgress(deckId,obj){
   const dk = deckId || deckKeyFromState();

--- a/js/bundle.js
+++ b/js/bundle.js
@@ -139,6 +139,8 @@ function fireProgressEvent(payload){
     entry.seenCount += 1;
     entry.lastSeen = today;
     if(!entry.introducedAt) entry.introducedAt = new Date().toISOString();
+    if(typeof entry.interval !== 'number') entry.interval = 1;
+    entry.interval = FC_UTILS.clampInterval(entry.interval);
     prog.seen[cardId] = entry;
     localStorage.setItem(progressKey, JSON.stringify(prog));
     if(!wasSeen){ FC_UTILS.consumeNewAllowance(); }
@@ -1745,8 +1747,18 @@ function todayKey() {
 function loadProgress(deckId){
   const dk = deckId || deckKeyFromState();
   const progressKey = LS_PROGRESS_PREFIX + dk;
-  try{ return JSON.parse(localStorage.getItem(progressKey) || '{}'); }
-  catch { return {}; }
+  let obj;
+  try{ obj = JSON.parse(localStorage.getItem(progressKey) || '{}'); }
+  catch{ obj = {}; }
+  const seen = obj.seen || {};
+  Object.keys(seen).forEach(id => {
+    const entry = seen[id] || {};
+    const n = typeof entry.interval === 'number' ? entry.interval : 1;
+    entry.interval = FC_UTILS.clampInterval(n);
+    seen[id] = entry;
+  });
+  obj.seen = seen;
+  return obj;
 }
 function saveProgress(deckId,obj){
   const dk = deckId || deckKeyFromState();

--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -205,6 +205,8 @@ function markSeenNow(cardId){
   entry.seenCount += 1;
   entry.lastSeen = today;
   if(!entry.introducedAt) entry.introducedAt = new Date().toISOString();
+  if(typeof entry.interval !== 'number') entry.interval = 1;
+  entry.interval = FC_UTILS.clampInterval(entry.interval);
   prog.seen[cardId] = entry;
   localStorage.setItem(progressKey, JSON.stringify(prog));
   if(!wasSeen){ FC_UTILS.consumeNewAllowance(); }

--- a/js/utils.js
+++ b/js/utils.js
@@ -80,6 +80,13 @@
     return { remaining: state.remaining };
   }
 
+  function clampInterval(n){
+    n = typeof n === 'number' ? Math.round(n) : 1;
+    if(n < 1) n = 1;
+    if(n > 365) n = 365;
+    return n;
+  }
+
   function deckKeyFromState(){
     const map = {
       'Welsh – A1 Phrases': 'welsh_phrases_A1',
@@ -114,7 +121,8 @@
     getLocalISODate,
     getDailyNewAllowance,
     consumeNewAllowance,
-    peekAllowance
+    peekAllowance,
+    clampInterval
   };
 
   global.logReview = logReview;


### PR DESCRIPTION
## Summary
- store `interval` (days until next review) with each phrase
- default interval to 1 on first introduction and clamp to 1-365
- expose `clampInterval` helper in `FC_UTILS` and normalize progress on load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a233762e20833086145879c632b0eb