### PR TITLE
Wire intro path into New Phrases module

### DIFF
--- a/js/srs.js
+++ b/js/srs.js
@@ -133,3 +133,7 @@ export default {
   nextIntervalsForNew,
   applyIntroPath
 };
+
+if (typeof window !== 'undefined') {
+  window.FC_SRS = { scheduleNextReview, nextIntervalsForNew, applyIntroPath, persistCard };
+}


### PR DESCRIPTION
## Summary
- Schedule introductory reviews when a new phrase is first shown and after completion.
- Expose SRS helpers globally so the New Phrases flow can apply intro steps.
- Show upcoming review time in the New Phrases footer.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a23c5754788330b6b94c0b21cc2295