### PR TITLE
Add Grace Mode scheduler option

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2,7 +2,10 @@
 
 const DECKS = [{ id: 'welsh_phrases_A1', name: 'Welsh – A1 Phrases', count: 116 }];
 
-const SETTINGS = { newPerDay: 5 };
+const SETTINGS = {
+  newPerDay: 5,
+  graceMode: loadGraceMode()
+};
 
 const STORAGE = {
   theme: 'fc_theme',
@@ -172,6 +175,15 @@ function loadExamplesEN() {
 function setExamplesEN(v) {
   STATE.showExamplesEN = !!v;
   localStorage.setItem(STORAGE.examplesEN, String(!!v));
+}
+
+function loadGraceMode() {
+  const saved = localStorage.getItem('graceMode');
+  return saved === null ? true : saved === 'true';
+}
+function setGraceMode(v) {
+  SETTINGS.graceMode = !!v;
+  localStorage.setItem('graceMode', String(SETTINGS.graceMode));
 }
 
 async function updateStatusPills(){
@@ -569,6 +581,23 @@ function renderSettings(){
     list.appendChild(card);
   });
   wrap.appendChild(list);
+
+  const sub2 = document.createElement('h2');
+  sub2.className = 'h2';
+  sub2.textContent = 'Options';
+  wrap.appendChild(sub2);
+
+  const optCard = document.createElement('div');
+  optCard.className = 'card';
+  optCard.style.padding = '10px';
+  optCard.innerHTML = `
+    <label style="display:flex; align-items:center; gap:8px; cursor:pointer;">
+      <input type="checkbox" id="graceToggle"> Grace Mode (don’t shorten on late reviews)
+    </label>`;
+  const chk = optCard.querySelector('input');
+  chk.checked = SETTINGS.graceMode;
+  chk.addEventListener('change', e => setGraceMode(e.target.checked));
+  wrap.appendChild(optCard);
   return wrap;
 }
 

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -14,6 +14,8 @@
   const SCORE_COOLDOWN_MS = 60 * 60 * 1000; // do not count another "pass" within 1h
   const SCORE_WINDOW      = 10;       // last-N window for confidence/accuracy
 
+  const FC_SRS = window.FC_SRS || {};
+
   // Behaviour thresholds
   const THINK_MIN_S     = 6;
   const THINK_MAX_S     = 45;     // nudge at this time
@@ -371,6 +373,9 @@
       forceNoScore: practiceMode
     });
     logReview(c, pass ? 'pass' : 'fail');
+    if (FC_SRS.scheduleNextReview) {
+      FC_SRS.scheduleNextReview(c, pass ? 'pass' : 'fail', { now: new Date(), grace: SETTINGS.graceMode });
+    }
 
     fireProgressEvent({ type:'attempt', id:c.id, pass });
 
@@ -414,6 +419,9 @@
         const ok = equalsLoose(val, card.front);
         logAttempt(card.id, ok, { behaviour: localTracker.classify().kind, forceNoScore: true });
         logReview(card, ok ? 'pass' : 'fail');
+        if (FC_SRS.scheduleNextReview) {
+          FC_SRS.scheduleNextReview(card, ok ? 'pass' : 'fail', { now: new Date(), grace: SETTINGS.graceMode });
+        }
         fireProgressEvent({ type:'attempt', id: card.id, pass: ok });
         if (ok){
           if (step===1) copyStep(2);
@@ -448,6 +456,9 @@
         const ok = equalsLoose(val, card.front);
         const counted = logAttempt(card.id, ok, { behaviour: localTracker.classify().kind, forceNoScore: practiceMode });
         logReview(card, ok ? 'pass' : 'fail');
+        if (FC_SRS.scheduleNextReview) {
+          FC_SRS.scheduleNextReview(card, ok ? 'pass' : 'fail', { now: new Date(), grace: SETTINGS.graceMode });
+        }
         fireProgressEvent({ type:'attempt', id: card.id, pass: ok });
         if (ok){
           if (counted && !practiceMode) tickDay && tickDay();


### PR DESCRIPTION
## Summary
- add Grace Mode setting persisted in localStorage
- expose Grace Mode toggle in Settings
- forward Grace Mode to scheduler when logging reviews

## Testing
- `node --check js/app.js`
- `node --check js/testMode.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a23ece027c83308ffeb9c44c121e15