### PR TITLE
Add lightweight analytics and debug viewer

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Metrics Debug</title>
+<style>
+body{font-family:monospace;padding:20px;}
+pre{white-space:pre-wrap;word-break:break-word;background:#f0f0f0;padding:10px;border-radius:4px;}
+</style>
+</head>
+<body>
+<h1>Metrics</h1>
+<button id="clear">Clear</button>
+<pre id="dump"></pre>
+<script src="../js/metrics.js"></script>
+<script>
+function render(){
+  const data=(window.getMetrics&&window.getMetrics())||[];
+  document.getElementById('dump').textContent=JSON.stringify(data,null,2);
+}
+render();
+document.getElementById('clear').addEventListener('click',()=>{ window.clearMetrics&&window.clearMetrics(); render(); });
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -87,9 +87,13 @@
   </div>
 
   <script src="js/errorBanner.js" defer></script>
+  <script src="js/metrics.js" defer></script>
   <script src="js/utils.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
   <script src="js/bundle.js" defer></script>
+  <script src="js/newPhrase.js" defer></script>
+  <script src="js/testMode.js" defer></script>
+  <script src="js/study.js" defer></script>
   <script type="module" src="js/firebase.js"></script>
 </body>
 </html>

--- a/js/metrics.js
+++ b/js/metrics.js
@@ -1,0 +1,14 @@
+(function(){
+  function load(){
+    try{ return JSON.parse(localStorage.getItem('metrics') || '[]'); }
+    catch{ return []; }
+  }
+  window.recordEvent = function(name, payload){
+    const arr = load();
+    arr.push({ ts: Date.now(), name, payload });
+    if(arr.length > 500) arr.splice(0, arr.length - 500);
+    localStorage.setItem('metrics', JSON.stringify(arr));
+  };
+  window.getMetrics = load;
+  window.clearMetrics = function(){ localStorage.removeItem('metrics'); };
+})();

--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -602,6 +602,11 @@ function render(){
         const card = { id: c.id, introducedAt: entry && entry.introducedAt };
         FC_SRS.applyIntroPath && FC_SRS.applyIntroPath(card, 1);
         FC_SRS.persistCard && FC_SRS.persistCard(card);
+        recordEvent && recordEvent('intro_step', {
+          cardId: c.id,
+          stepIndex: 1,
+          scheduledFor: card.dueDate
+        });
         if(entry){
           entry.interval = card.interval;
           entry.dueDate = card.dueDate;

--- a/js/study.js
+++ b/js/study.js
@@ -100,6 +100,7 @@ async function renderReview(query) {
   cards = confKeys.flatMap(conf => shuffle(groups[conf]));
   console.log('[active-count]', deckKeyFromState(), cards.length);
   console.log('[progress-key-used]', progressKey);
+  recordEvent && recordEvent('session_started', { countDue: cards.length, countServed: cards.length });
 
   if (!cards.length) {
     const err = document.createElement('div');

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -350,7 +350,18 @@
     });
     logReview(c, pass ? 'pass' : 'fail');
     if (FC_SRS.scheduleNextReview) {
+      const beforeInt = c.interval;
+      const beforeDue = c.dueDate;
       FC_SRS.scheduleNextReview(c, pass ? 'pass' : 'fail', { now: new Date(), grace: SETTINGS.graceMode });
+      recordEvent && recordEvent('review_logged', {
+        cardId: c.id,
+        result: pass ? 'pass' : 'fail',
+        oldInterval: beforeInt,
+        newInterval: c.interval,
+        oldDue: beforeDue,
+        newDue: c.dueDate,
+        ease: c.ease
+      });
     }
 
     fireProgressEvent({ type:'attempt', id:c.id, pass });
@@ -396,7 +407,18 @@
         logAttempt(card.id, ok, { behaviour: localTracker.classify().kind, forceNoScore: true });
         logReview(card, ok ? 'pass' : 'fail');
         if (FC_SRS.scheduleNextReview) {
+          const bInt = card.interval;
+          const bDue = card.dueDate;
           FC_SRS.scheduleNextReview(card, ok ? 'pass' : 'fail', { now: new Date(), grace: SETTINGS.graceMode });
+          recordEvent && recordEvent('review_logged', {
+            cardId: card.id,
+            result: ok ? 'pass' : 'fail',
+            oldInterval: bInt,
+            newInterval: card.interval,
+            oldDue: bDue,
+            newDue: card.dueDate,
+            ease: card.ease
+          });
         }
         fireProgressEvent({ type:'attempt', id: card.id, pass: ok });
         if (ok){
@@ -433,7 +455,18 @@
         const counted = logAttempt(card.id, ok, { behaviour: localTracker.classify().kind, forceNoScore: practiceMode });
         logReview(card, ok ? 'pass' : 'fail');
         if (FC_SRS.scheduleNextReview) {
+          const bInt = card.interval;
+          const bDue = card.dueDate;
           FC_SRS.scheduleNextReview(card, ok ? 'pass' : 'fail', { now: new Date(), grace: SETTINGS.graceMode });
+          recordEvent && recordEvent('review_logged', {
+            cardId: card.id,
+            result: ok ? 'pass' : 'fail',
+            oldInterval: bInt,
+            newInterval: card.interval,
+            oldDue: bDue,
+            newDue: card.dueDate,
+            ease: card.ease
+          });
         }
         fireProgressEvent({ type:'attempt', id: card.id, pass: ok });
         if (ok){
@@ -533,6 +566,7 @@
       // Build "due" list and cap to session size
       const allDue = await buildActiveList();
       sessionDue = Math.min(allDue.length, SESSION_MAX);
+      recordEvent && recordEvent('session_started', { countDue: allDue.length, countServed: sessionDue });
       if(window.fcUpdateQuizBadge) window.fcUpdateQuizBadge(allDue.length);
       if (!allDue.length){
         container.innerHTML = `<div class="flashcard"><div class="flashcard-progress muted">No introduced cards due. Use New Phrases or come back later.</div></div>`;


### PR DESCRIPTION
## Summary
- Track session and review events via new `recordEvent` helper
- Log intro step events when new phrases are scheduled
- Provide simple `/debug` page to inspect and clear stored metrics

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a2445494748330b6b24e2edb347a2e