### PR TITLE
feat: track phrase review interval

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -335,13 +335,20 @@ function loadProgress(deckId){
   try { obj = JSON.parse(localStorage.getItem(progressKey) || '{}'); }
   catch { obj = {}; }
   const seen = obj.seen || {};
+  let changed = false;
   Object.keys(seen).forEach(id => {
     const entry = seen[id] || {};
-    const n = typeof entry.interval === 'number' ? entry.interval : 1;
-    entry.interval = FC_UTILS.clampInterval(n);
+    const before = entry.interval;
+    if (window.FC_SRS && FC_SRS.ensureInterval) {
+      FC_SRS.ensureInterval(entry);
+    }
+    if (entry.interval !== before) changed = true;
     seen[id] = entry;
   });
   obj.seen = seen;
+  if (changed) {
+    localStorage.setItem(progressKey, JSON.stringify(obj));
+  }
   return obj;
 }
 function saveProgress(deckId,obj){

--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -214,6 +214,8 @@ function markSeenNow(cardId){
     entry.interval = card.interval;
     entry.dueDate = card.dueDate;
     FC_UTILS.consumeNewAllowance();
+  } else {
+    FC_SRS.ensureInterval && FC_SRS.ensureInterval(entry);
   }
   prog.seen[cardId] = entry;
   localStorage.setItem(progressKey, JSON.stringify(prog));

--- a/js/study.js
+++ b/js/study.js
@@ -28,7 +28,22 @@ async function loadDeckSorted(deckId){
 }
 
 function loadProgressSeen(){
-  try { return (JSON.parse(localStorage.getItem(progressKey) || '{"seen":{}}').seen) || {}; }
+  try {
+    const obj = JSON.parse(localStorage.getItem(progressKey) || '{"seen":{}}');
+    const seen = obj.seen || {};
+    let changed = false;
+    Object.values(seen).forEach(entry => {
+      const before = entry.interval;
+      if (window.FC_SRS && FC_SRS.ensureInterval) {
+        FC_SRS.ensureInterval(entry);
+      }
+      if (entry.interval !== before) changed = true;
+    });
+    if (changed) {
+      localStorage.setItem(progressKey, JSON.stringify({ ...obj, seen }));
+    }
+    return seen;
+  }
   catch { return {}; }
 }
 

--- a/js/testMode.js
+++ b/js/testMode.js
@@ -190,7 +190,22 @@
 
   /* ---------- Progress / seen ---------- */
   function loadProgressSeen(){
-    try { return (JSON.parse(localStorage.getItem(progressKey) || '{"seen":{}}').seen) || {}; }
+    try {
+      const obj = JSON.parse(localStorage.getItem(progressKey) || '{"seen":{}}');
+      const seen = obj.seen || {};
+      let changed = false;
+      Object.values(seen).forEach(entry => {
+        const before = entry.interval;
+        if (window.FC_SRS && FC_SRS.ensureInterval) {
+          FC_SRS.ensureInterval(entry);
+        }
+        if (entry.interval !== before) changed = true;
+      });
+      if (changed) {
+        localStorage.setItem(progressKey, JSON.stringify({ ...obj, seen }));
+      }
+      return seen;
+    }
     catch { return {}; }
   }
   function isActiveCard(id, seen, attempts){

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "flashcards",
   "version": "1.0.0",
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "test:interval": "node tests/interval.spec.js"
+  }
 }

--- a/tests/interval.spec.js
+++ b/tests/interval.spec.js
@@ -1,0 +1,52 @@
+import { clampInterval, ensureInterval, scheduleNextReview } from '../js/srs.js';
+import { persistCard, loadDeck, saveDeck } from '../js/storage.js';
+
+function assert(name, fn) {
+  try {
+    fn();
+    console.log('✅', name);
+  } catch (err) {
+    console.error('❌', name, err.message);
+  }
+}
+
+global.localStorage = {
+  store: {},
+  getItem(key) { return this.store[key] || null; },
+  setItem(key, val) { this.store[key] = String(val); },
+  removeItem(key) { delete this.store[key]; }
+};
+
+function resetStore() {
+  global.localStorage.store = {};
+}
+
+assert('ensureInterval defaults to 1', () => {
+  const card = {};
+  ensureInterval(card);
+  if (card.interval !== 1) throw new Error('interval');
+});
+
+assert('clampInterval clamps range', () => {
+  if (clampInterval(0) !== 1) throw new Error('low');
+  if (clampInterval(400) !== 365) throw new Error('high');
+});
+
+assert('scheduleNextReview persists interval', () => {
+  resetStore();
+  const now = new Date('2024-01-01T00:00:00Z');
+  const card = { id: 'x', interval: 1, ease: 2.5, dueDate: now.toISOString(), reviews: [] };
+  scheduleNextReview(card, 'pass', { now });
+  const deck = loadDeck();
+  if (!deck.length || deck[0].interval !== card.interval) throw new Error('persist');
+});
+
+assert('migration fills missing interval', () => {
+  resetStore();
+  saveDeck([{ id: 'm', dueDate: new Date().toISOString() }]);
+  const deck = loadDeck();
+  const phrase = ensureInterval(deck[0]);
+  persistCard(phrase);
+  const deck2 = loadDeck();
+  if (deck2[0].interval !== 1) throw new Error('migrated');
+});


### PR DESCRIPTION
## Summary
- add clampInterval and ensureInterval helpers for phrase scheduling
- migrate stored progress to ensure a valid interval field
- test interval persistence and migration

## Testing
- `node tests/srs.spec.js`
- `node tests/srs.life.spec.js`
- `npm run test:interval`


------
https://chatgpt.com/codex/tasks/task_e_68a24db2b3c08330a7530475432a7b21