### PR TITLE
Add due-date scheduling and persistence

### DIFF
--- a/js/data.js
+++ b/js/data.js
@@ -8,26 +8,28 @@
     const seen = prog.seen || {};
     const session = (()=>{ try{ return JSON.parse(localStorage.getItem(SESSION_KEY) || '{}'); } catch{ return {}; } })();
     const doneSet = new Set(session.done || []);
-    const day = new Date(asOfDate); day.setHours(0,0,0,0);
-    const now = day.getTime();
+    const day = new Date(asOfDate); day.setUTCHours(0,0,0,0);
 
-    return rows.filter(r => {
+    const candidates = rows.filter(r => {
       if(!(seen[r.id] || (attempts[r.id] && attempts[r.id].length))) return false;
       if(doneSet.has(r.id)) return false;
       const arr = attempts[r.id] || [];
       for(let i=arr.length-1;i>=0;i--){
         const a = arr[i];
         if(a.pass && a.score !== false){
-          if(now - a.ts < SCORE_COOLDOWN_MS) return false;
+          if(day.getTime() - a.ts < SCORE_COOLDOWN_MS) return false;
           break;
         }
       }
-      const dueStr = seen[r.id] && seen[r.id].dueDate;
-      const due = dueStr ? Date.parse(dueStr) : 0;
-      if(due > now) return false;
-      r.due = due;
       return true;
-    }).sort((a,b)=>a.due - b.due);
+    }).map(r => ({ ...r, dueDate: seen[r.id] && seen[r.id].dueDate }));
+
+    const due = (global.FC_SRS && FC_SRS.getDuePhrases)
+      ? FC_SRS.getDuePhrases(candidates, day)
+      : candidates.filter(c => c.dueDate && new Date(c.dueDate) <= day)
+          .sort((a,b)=>new Date(a.dueDate)-new Date(b.dueDate));
+
+    return due.map(r => ({ ...r, due: Date.parse(r.dueDate || 0) }));
   }
 
   global.getDueCards = getDueCards;

--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -207,7 +207,7 @@ function markSeenNow(cardId){
   if(!wasSeen){
     entry.seenCount = 1;
     entry.introducedAt = new Date().toISOString();
-    // Intro step 0: schedule same-day review
+    // Intro step 0: schedule initial review
     const card = { id: cardId, introducedAt: entry.introducedAt };
     FC_SRS.applyIntroPath && FC_SRS.applyIntroPath(card, 0);
     FC_SRS.persistCard && FC_SRS.persistCard(card);
@@ -216,6 +216,9 @@ function markSeenNow(cardId){
     FC_UTILS.consumeNewAllowance();
   } else {
     FC_SRS.ensureInterval && FC_SRS.ensureInterval(entry);
+    if(!entry.dueDate && FC_SRS.calcDueDateFromInterval){
+      entry.dueDate = FC_SRS.calcDueDateFromInterval(new Date(), entry.interval);
+    }
   }
   prog.seen[cardId] = entry;
   localStorage.setItem(progressKey, JSON.stringify(prog));

--- a/js/storage.js
+++ b/js/storage.js
@@ -14,11 +14,44 @@ export function saveDeck(deck) {
   }
 }
 
+function startOfTodayISO(now = new Date()) {
+  const d = new Date(now);
+  d.setUTCHours(0, 0, 0, 0);
+  return d.toISOString();
+}
+
+function addDaysISO(iso, days) {
+  const d = new Date(iso);
+  d.setUTCDate(d.getUTCDate() + (days || 0));
+  return d.toISOString();
+}
+
+function calcDue(now, interval) {
+  const base = startOfTodayISO(now);
+  return addDaysISO(base, Math.max(1, Math.round(interval || 1)));
+}
+
 /** Load the current deck. */
 export function loadDeck() {
   try {
     const raw = localStorage.getItem(DECK_KEY);
-    return raw ? JSON.parse(raw) : [];
+    const deck = raw ? JSON.parse(raw) : [];
+    const now = new Date();
+    let updated = false;
+    for (const card of deck) {
+      if (typeof card.interval !== 'number' || !isFinite(card.interval)) {
+        card.interval = 1;
+        updated = true;
+      } else {
+        card.interval = Math.max(1, Math.min(365, Math.round(card.interval)));
+      }
+      if (!card.dueDate || isNaN(Date.parse(card.dueDate))) {
+        card.dueDate = calcDue(now, card.interval);
+        updated = true;
+      }
+    }
+    if (updated) saveDeck(deck);
+    return deck;
   } catch {
     return [];
   }

--- a/js/utils.js
+++ b/js/utils.js
@@ -88,9 +88,12 @@
   }
 
   function calcDueDate(intervalDays){
+    if(global.FC_SRS && global.FC_SRS.calcDueDateFromInterval){
+      return FC_SRS.calcDueDateFromInterval(new Date(), intervalDays);
+    }
     const d = new Date();
-    d.setHours(0,0,0,0);
-    d.setDate(d.getDate() + (typeof intervalDays === 'number' ? intervalDays : 1));
+    d.setUTCHours(0,0,0,0);
+    d.setUTCDate(d.getUTCDate() + (typeof intervalDays === 'number' ? intervalDays : 1));
     return d.toISOString();
   }
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test:interval": "node tests/interval.spec.js"
+    "test:interval": "node tests/interval.spec.js",
+    "test:due": "node tests/dueDate.spec.js"
   }
 }

--- a/tests/dueDate.spec.js
+++ b/tests/dueDate.spec.js
@@ -1,0 +1,59 @@
+import { applyIntroPath, scheduleNextReview, calcDueDateFromInterval, startOfTodayISO, addDaysISO, getDuePhrases } from '../js/srs.js';
+
+function assert(name, fn){
+  try{ fn(); console.log('✅', name); }
+  catch(err){ console.error('❌', name, err.message); }
+}
+
+global.localStorage = {
+  store:{},
+  getItem(k){ return this.store[k] || null; },
+  setItem(k,v){ this.store[k]=String(v); },
+  removeItem(k){ delete this.store[k]; }
+};
+
+function resetStore(){ global.localStorage.store = {}; }
+
+assert('intro sets dueDate to tomorrow', () => {
+  resetStore();
+  const now = new Date('2024-01-01T12:00:00Z');
+  const card = { id:'n1', introducedAt: now.toISOString(), reviews: [] };
+  applyIntroPath(card, 0, { now });
+  const expected = new Date('2024-01-02T00:00:00.000Z').toISOString();
+  if(card.interval !== 1) throw new Error('interval');
+  if(card.dueDate !== expected) throw new Error(`due ${card.dueDate}`);
+});
+
+assert('review updates interval and dueDate', () => {
+  resetStore();
+  const now = new Date('2024-01-01T00:00:00Z');
+  const card = { id:'n2', interval:1, ease:2.5, dueDate: calcDueDateFromInterval(now,1), reviews: [] };
+  scheduleNextReview(card,'pass',{ now });
+  const expected = new Date('2024-01-04T00:00:00.000Z').toISOString();
+  if(card.interval !== 3) throw new Error(`interval ${card.interval}`);
+  if(card.dueDate !== expected) throw new Error(`due ${card.dueDate}`);
+});
+
+assert('grace review schedules from original due date', () => {
+  resetStore();
+  const original = new Date('2024-01-03T00:00:00Z');
+  const card = { id:'n3', interval:2, ease:2.5, dueDate: original.toISOString(), reviews: [] };
+  const now = new Date('2024-01-05T00:00:00Z');
+  scheduleNextReview(card,'pass',{ now, grace:true });
+  const baseISO = startOfTodayISO(original);
+  const expected = addDaysISO(baseISO, card.interval);
+  if(card.dueDate !== expected) throw new Error(`due ${card.dueDate}`);
+  if(new Date(card.dueDate) <= now) throw new Error('not future');
+});
+
+assert('getDuePhrases filters and sorts by dueDate', () => {
+  const now = new Date('2024-01-05T00:00:00Z');
+  const list = [
+    { id:'a', dueDate:'2024-01-04T00:00:00Z' },
+    { id:'b', dueDate:'2024-01-03T00:00:00Z' },
+    { id:'c', dueDate:'2024-01-06T00:00:00Z' }
+  ];
+  const due = getDuePhrases(list, now);
+  const ids = due.map(p=>p.id).join(',');
+  if(ids !== 'b,a') throw new Error(ids);
+});

--- a/tests/srs.life.spec.js
+++ b/tests/srs.life.spec.js
@@ -42,11 +42,11 @@ assert('Card life cycle through intro, reviews, grace and easy', () => {
   scheduleNextReview(card, 'fail', { now: day1 });
   if (card.interval !== 1) throw new Error(`interval ${card.interval}`);
   if (Math.abs(card.ease - 2.3) > 1e-9) throw new Error(`ease ${card.ease}`);
-  if (card.dueDate !== day1.toISOString()) throw new Error('due after fail');
+  const day2 = addDays(day1, 1);
+  if (card.dueDate !== day2.toISOString()) throw new Error('due after fail');
   if (card.reviews.length !== 1 || card.reviews[0].result !== 'fail') throw new Error('review log after fail');
 
   // Next day: pass
-  const day2 = addDays(day1, 1);
   scheduleNextReview(card, 'pass', { now: day2 });
   const day4 = addDays(day2, 2);
   if (card.interval !== 2) throw new Error(`interval2 ${card.interval}`);

--- a/tests/srs.spec.js
+++ b/tests/srs.spec.js
@@ -31,14 +31,15 @@ assert('PASS increases interval and ease, sets dueDate to now+interval', () => {
   if (card.dueDate !== expectedDue) throw new Error('dueDate');
 });
 
-assert('FAIL halves interval, decreases ease, due today', () => {
+assert('FAIL halves interval, decreases ease, schedules from today', () => {
   resetStore();
   const now = new Date('2024-01-01T00:00:00Z');
   const card = { id: '2', interval: 10, ease: 2.5, dueDate: now.toISOString(), reviews: [] };
   scheduleNextReview(card, 'fail', { now });
+  const expectedDue = new Date('2024-01-06T00:00:00.000Z').toISOString();
   if (card.interval !== 5) throw new Error('interval');
   if (Math.abs(card.ease - 2.3) > 1e-9) throw new Error('ease');
-  if (card.dueDate !== now.toISOString()) throw new Error('dueDate');
+  if (card.dueDate !== expectedDue) throw new Error('dueDate');
 });
 
 assert('EASY multiplies interval by ease*1.5 and clamps to 365 days', () => {
@@ -76,7 +77,8 @@ assert('applyIntroPath schedules steps without logging reviews', () => {
   const now = new Date('2024-01-01T00:00:00Z');
   const card = { id: '6', reviews: [] };
   applyIntroPath(card, 0, { now });
-  if (card.interval !== 1 || card.dueDate !== now.toISOString()) throw new Error('step0');
+  const step0Due = new Date('2024-01-02T00:00:00.000Z').toISOString();
+  if (card.interval !== 1 || card.dueDate !== step0Due) throw new Error('step0');
   applyIntroPath(card, 1, { now });
   const step1Due = new Date('2024-01-02T00:00:00.000Z').toISOString();
   if (card.interval !== 1 || card.dueDate !== step1Due) throw new Error('step1');


### PR DESCRIPTION
## Summary
- compute next-review timestamps using new ISO utilities and recompute after every review
- persist and migrate `dueDate` for stored phrases and ensure new phrases get scheduled
- centralize due filtering/sorting with `getDuePhrases` and update quiz counts

## Testing
- `node tests/srs.spec.js`
- `node tests/srs.life.spec.js`
- `npm run test:interval`
- `npm run test:due`


------
https://chatgpt.com/codex/tasks/task_e_68a24f5e066c83308d08b7ed86a9e696