### PR TITLE
Add ease helpers and interval computation

### DIFF
--- a/js/newPhrase.js
+++ b/js/newPhrase.js
@@ -208,7 +208,7 @@ function markSeenNow(cardId){
     entry.seenCount = 1;
     entry.introducedAt = new Date().toISOString();
     // Intro step 0: schedule initial review
-    const card = { id: cardId, introducedAt: entry.introducedAt };
+    const card = { id: cardId, introducedAt: entry.introducedAt, ease: 2.5 };
     FC_SRS.applyIntroPath && FC_SRS.applyIntroPath(card, 0);
     FC_SRS.persistCard && FC_SRS.persistCard(card);
     entry.interval = card.interval;

--- a/js/srs.js
+++ b/js/srs.js
@@ -53,6 +53,62 @@ function clamp(val, min, max) {
   return Math.min(Math.max(val, min), max);
 }
 
+/** Clamp ease value to supported range. */
+export function clampEase(e) {
+  return clamp(typeof e === 'number' ? e : 2.5, 1.3, 3.0);
+}
+
+/**
+ * Adjust an ease value based on a review result.
+ * @param {number} ease Current ease.
+ * @param {('fail'|'hard'|'pass'|'easy')} result Review outcome.
+ * @returns {number} New ease, clamped to [1.3,3.0].
+ */
+export function adjustEase(ease, result) {
+  let next = typeof ease === 'number' ? ease : 2.5;
+  switch (result) {
+    case 'fail':
+      next -= 0.20; break;
+    case 'hard':
+      next -= 0.05; break;
+    case 'pass':
+      next += 0.05; break;
+    case 'easy':
+      next += 0.10; break;
+  }
+  return clampEase(next);
+}
+
+/**
+ * Compute the next interval in days given current interval, ease and result.
+ * @param {number} interval Current interval in days.
+ * @param {number} ease Current ease factor.
+ * @param {('fail'|'hard'|'pass'|'easy')} result Review outcome.
+ * @returns {number} Next interval in days (clamped to [1,365]).
+ */
+export function computeNextInterval(interval, ease, result) {
+  const cur = typeof interval === 'number' && isFinite(interval) ? interval : 1;
+  const e = typeof ease === 'number' && isFinite(ease) ? ease : 2.5;
+  let days;
+  switch (result) {
+    case 'fail':
+      days = Math.max(1, Math.floor(cur / 2));
+      break;
+    case 'hard':
+      days = Math.round(cur);
+      break;
+    case 'pass':
+      days = Math.round(cur * e);
+      break;
+    case 'easy':
+      days = Math.round(cur * e * 1.5);
+      break;
+    default:
+      days = Math.round(cur);
+  }
+  return clampInterval(days);
+}
+
 /**
  * Compute the next review schedule for a card based on the result of a review.
  *
@@ -152,6 +208,9 @@ export default {
   applyIntroPath,
   clampInterval,
   ensureInterval,
+  clampEase,
+  adjustEase,
+  computeNextInterval,
   startOfTodayISO,
   addDaysISO,
   calcDueDateFromInterval,
@@ -167,6 +226,9 @@ if (typeof window !== 'undefined') {
     persistCard,
     clampInterval,
     ensureInterval,
+    clampEase,
+    adjustEase,
+    computeNextInterval,
     startOfTodayISO,
     addDaysISO,
     calcDueDateFromInterval,

--- a/js/storage.js
+++ b/js/storage.js
@@ -49,6 +49,16 @@ export function loadDeck() {
         card.dueDate = calcDue(now, card.interval);
         updated = true;
       }
+      if (typeof card.ease !== 'number' || !isFinite(card.ease)) {
+        card.ease = 2.5;
+        updated = true;
+      } else {
+        const clamped = Math.min(3.0, Math.max(1.3, card.ease));
+        if (clamped !== card.ease) {
+          card.ease = clamped;
+          updated = true;
+        }
+      }
     }
     if (updated) saveDeck(deck);
     return deck;

--- a/tests/srs.spec.js
+++ b/tests/srs.spec.js
@@ -1,4 +1,4 @@
-import { scheduleNextReview, applyIntroPath } from '../js/srs.js';
+import { scheduleNextReview, applyIntroPath, adjustEase, computeNextInterval } from '../js/srs.js';
 
 function assert(name, fn) {
   try {
@@ -86,5 +86,17 @@ assert('applyIntroPath schedules steps without logging reviews', () => {
   const step2Due = new Date('2024-01-04T00:00:00.000Z').toISOString();
   if (card.interval !== 3 || card.dueDate !== step2Due) throw new Error('step2');
   if (card.reviews.length !== 0) throw new Error('reviews');
+});
+
+// Helper function tests
+assert('adjustEase and computeNextInterval helpers', () => {
+  const phrase = { interval: 2, ease: 2.5 };
+  if (adjustEase(2.5, 'fail') !== 2.3) throw new Error('adj1');
+  if (adjustEase(2.3, 'easy') !== 2.4) throw new Error('adj2');
+  if (adjustEase(2.95, 'easy') !== 3.0) throw new Error('adj3');
+  if (computeNextInterval(2, 2.4, 'pass') !== 5) throw new Error('int1');
+  if (computeNextInterval(5, 2.4, 'easy') !== 18) throw new Error('int2');
+  if (computeNextInterval(5, 2.0, 'fail') !== 2) throw new Error('int3');
+  if (computeNextInterval(1, 1.5, 'fail') !== 1) throw new Error('int4');
 });
 


### PR DESCRIPTION
## Summary
- track an `ease` factor on phrases with default 2.5
- expose `clampEase`, `adjustEase`, and `computeNextInterval` helpers for upcoming scheduler work
- migrate stored cards to include the new ease field

## Testing
- `node tests/srs.spec.js`
- `node tests/interval.spec.js`
- `node tests/dueDate.spec.js`
- `node tests/srs.due.spec.js`
- `node tests/srs.life.spec.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2c13616c08330b5b6e182362be7be